### PR TITLE
header protection in input_database did not match #ifdef to #define

### DIFF
--- a/pfsimulator/parflow_lib/input_database.h
+++ b/pfsimulator/parflow_lib/input_database.h
@@ -27,7 +27,7 @@
 **********************************************************************EHEADER*/
 
 #ifndef _INPUT_DATABASE_HEADER
-#define _INPUT_DATABASE
+#define _INPUT_DATABASE_HEADER
 
 #include "hbt.h"
 


### PR DESCRIPTION
Pretty obvious, just a typo in which an:
```
#ifdef PROTECTION_HEADER
#define PROTETION
...
#endif
```

didnt' match.  (Note the Hypre and Silo issues were fixed when I went to the github repo instead of the svn one).