### PR TITLE
Crater2D regression test fix

### DIFF
--- a/test/crater2D_vangtable_spline.tcl
+++ b/test/crater2D_vangtable_spline.tcl
@@ -510,8 +510,11 @@ if ![pftestFile $runname.out.porosity.pfb "Max difference in porosity" $sig_digi
     set passed 0
 }
 
+# Pressure was very close to zero and test was failing so ignore very small pressures even if
+# the numbers differ in sig_digits
+set abs_diff 1E-200
 foreach i "00000 00001 00002" {
-    if ![pftestFile $runname.out.press.$i.pfb "Max difference in Pressure for timestep $i" $sig_digits] {
+    if ![pftestFileWithAbs $runname.out.press.$i.pfb "Max difference in Pressure for timestep $i" $sig_digits $abs_diff] {
 	set passed 0
     }
     if ![pftestFile $runname.out.satur.$i.pfb "Max difference in Saturation for timestep $i" $sig_digits] {

--- a/test/pftest.llnl.cab.msub
+++ b/test/pftest.llnl.cab.msub
@@ -1,10 +1,9 @@
 #!/bin/sh
 ##### These lines are for Moab
 #MSUB -l nodes=1
-#MSUB -l partition=atlas
-#MSUB -l walltime=0:30:00
+#MSUB -l walltime=0:20:00
+#MSUB -A gridopt
 #MSUB -q pbatch
-#MSUB -m be
 #MSUB -V
 
 ##### These are shell commands

--- a/test/pftest.llnl.quartz.sbatch
+++ b/test/pftest.llnl.quartz.sbatch
@@ -1,0 +1,10 @@
+#!/bin/sh
+#SBATCH -N 1
+#SBATCH -t 0:30:00
+#SBATCH -A cescyber
+#SBATCH -p pbatch
+
+date
+make check
+
+echo 'Done'

--- a/test/pftest.tcl
+++ b/test/pftest.tcl
@@ -10,20 +10,30 @@ proc pftestIsEqual {a b message} {
     }
 }
 
+proc eps {{base 1}} {
+    set eps 1e-20
+    while {$base-$eps==$base} {
+        set eps [expr {$eps+1e-22}]
+    }
+    set eps     [expr {$eps+1e-22}]
+}
+
 proc pftestFile {file message sig_digits} {
     if [file exists $file] {
 	set correct [pfload correct_output/$file]
 	set new     [pfload                $file]
 	set diff [pfmdiff $new $correct $sig_digits]
 	if {[string length $diff] != 0 } {
-	    puts "FAILED : $message"
 
 	    set mSigDigs [lindex $diff 0]
 	    set maxAbsDiff [lindex $diff 1]
 
 	    set i [lindex $mSigDigs 0]
 	    set j [lindex $mSigDigs 1]
-	    set k [lindex $mSigDigs 2] 
+	    set k [lindex $mSigDigs 2]
+
+	    puts "FAILED : $message"
+
 	    puts [format "\tMinimum significant digits at (% 3d, % 3d, % 3d) = %2d"\
 		      $i $j $k [lindex $mSigDigs 3]]
 


### PR DESCRIPTION
The crater2d_vangtable_spline regression test was signalling a failure when pressure values near zero were showing significant digit differences.   Comparison was changed so that pressure value differences near absolute zero are ignored.
Closes #29 