### PR TITLE
Nc pf additional output

### DIFF
--- a/pfsimulator/parflow_lib/parflow_netcdf.h
+++ b/pfsimulator/parflow_lib/parflow_netcdf.h
@@ -26,9 +26,14 @@
 #else
 #define MAX_NC_VARS 8192
 #endif
+#include<stdbool.h>
 
-static int ncID, xID, yID, zID, timID, varID;
+static int ncID, xID, yID, zID, lev1ID, timID, varID;
 static int time_step = 0;
+static bool is2Ddefined = false;
+static bool is3Ddefined = false;
+static bool isTdefined = false;
+
 typedef struct
 {
 	char *varName;
@@ -38,8 +43,9 @@ typedef struct
 } varNCData;
 
 void WritePFNC(char * file_prefix, char* file_postfix, double t, Vector  *v, int numVarTimeVariant,
-			char *varName, int dimensionality, int timDimensionality);
+			char *varName, int dimensionality, bool init, int numVarIni);
 void CreateNCFile(char *file_name, Vector *v);
+void NCDefDimensions(Vector *v, int dimensionality);
 void CloseNC(int ncID);
 int LookUpInventory(char * varName, varNCData **myVarNCData);
 void PutDataInNC(int varID, Vector *v, double t, varNCData *myVarNCData);

--- a/pftools/docs/usr_manual/files.tex
+++ b/pftools/docs/usr_manual/files.tex
@@ -4287,6 +4287,60 @@ pfset NetCDF.WritePressure    True
 pfset NetCDF.WriteSaturation    True
 \end{verbatim}\end{display}
 
+\pfkey{string}{NetCDF.WriteMannings}{False}
+{This key sets Mannings coefficients to be written in NetCDF4 file.} 
+\begin{display}\begin{verbatim}
+pfset NetCDF.WriteMannings	    True
+\end{verbatim}\end{display}
+
+\pfkey{string}{NetCDF.WriteSubsurface}{False}
+{This key sets subsurface data(permeabilities, porosity, specific storage) to be written in NetCDF4 file.} 
+\begin{display}\begin{verbatim}
+pfset NetCDF.WriteSubsurface	    True
+\end{verbatim}\end{display}
+
+\pfkey{string}{NetCDF.WriteSlopes}{False}
+{This key sets x and y slopes to be written in NetCDF4 file.} 
+\begin{display}\begin{verbatim}
+pfset NetCDF.WriteSlopes	    True
+\end{verbatim}\end{display}
+
+\pfkey{string}{NetCDF.WriteMask}{False}
+{This key sets mask to be written in NetCDF4 file.} 
+\begin{display}\begin{verbatim}
+pfset NetCDF.WriteMask	    True
+\end{verbatim}\end{display}
+
+\pfkey{string}{NetCDF.WriteDZMultiplier}{False}
+{This key sets DZ multipliers to be written in NetCDF4 file.} 
+\begin{display}\begin{verbatim}
+pfset NetCDF.WriteDZMultiplier	    True
+\end{verbatim}\end{display}
+
+\pfkey{string}{NetCDF.WriteEvapTrans}{False}
+{This key sets Evaptrans to be written in NetCDF4 file.} 
+\begin{display}\begin{verbatim}
+pfset NetCDF.WriteEvapTrans	    True
+\end{verbatim}\end{display}
+
+\pfkey{string}{NetCDF.WriteEvapTransSum}{False}
+{This key sets Evaptrans sum to be written in NetCDF4 file.} 
+\begin{display}\begin{verbatim}
+pfset NetCDF.WriteEvapTransSum	    True
+\end{verbatim}\end{display}
+
+\pfkey{string}{NetCDF.WriteOverlandSum}{False}
+{This key sets overland sum to be written in NetCDF4 file.} 
+\begin{display}\begin{verbatim}
+pfset NetCDF.WriteOverlandSum	    True
+\end{verbatim}\end{display}
+
+\pfkey{string}{NetCDF.WriteOverlandBCFlux}{False}
+{This key sets overland bc flux to be written in NetCDF4 file.} 
+\begin{display}\begin{verbatim}
+pfset NetCDF.WriteOverlandBCFlux	    True
+\end{verbatim}\end{display}
+
 \subsection{NetCDF4 Chunking}
 Chunking may have significant impact on I/O. If this key is not set, default chunking scheme will be used by NetCDF library. Chunks are hypercube(hyperslab) of any dimension. When chunking is used, chunks are written in single write operation which can reduce access times. For more information on chunking, refer to NetCDF4 user guide.
 
@@ -4335,7 +4389,7 @@ cb_buffer_size 33554432
 
 \subsection{Node Level Collective I/O}
 A node level collective strategy has been implemented for I/O. One process on each compute node gathers the data, indices and counts from the participating processes on same compute node. All the root processes from each compute node open a parallel NetCDF4 file and write the data. e.g. If ParFlow is running on 3 compute nodes where each node consists of 24 processors(cores); only 3 I/O streams to filesystem would be opened by each root processor each compute node. This strategy could be particularly useful when ParFlow is running on large number of processors and every processor participating in I/O may create a bottleneck.
-\textit{\textbf{Node level collective I/O is currently implemented for 2-D domain decomposition only. Moreover on speciality architectures, this may not be a portable feature. Users are advised to test this feature on their machine before putting into production.}}
+\textit{\textbf{Node level collective I/O is currently implemented for 2-D domain decomposition and variables Pressure and Saturation only. Moreover on speciality architectures, this may not be a portable feature. Users are advised to test this feature on their machine before putting into production.}}
 
 \pfkey{string}{NetCDF.NodeLevelIO}{False}
 {This key sets flag for node level collective I/O.} 

--- a/test/default_richards_with_netcdf.tcl
+++ b/test/default_richards_with_netcdf.tcl
@@ -376,7 +376,7 @@ if ![file exists default_richards.out.00000.nc] {
     set passed 0
 }
 
-if ![file exists default_richards.out.00005.nc] {
+if ![file exists default_richards.out.00001.nc] {
     puts "NetCDF file was not created"
     set passed 0
 }

--- a/test/washita/tcl_scripts/LW_NetCDF_Test.tcl
+++ b/test/washita/tcl_scripts/LW_NetCDF_Test.tcl
@@ -500,7 +500,6 @@ pfset NetCDF.WriteEvapTrans			True
 pfset NetCDF.WriteEvapTransSum			True
 pfset NetCDF.WriteOverlandSum			True
 pfset NetCDF.WriteOverlandBCFlux			True
-pfset Solver.PrintOverlandBCFlux			True
 
 #-----------------------------------------------------------------------------
 # Distribute inputs

--- a/test/washita/tcl_scripts/LW_NetCDF_Test.tcl
+++ b/test/washita/tcl_scripts/LW_NetCDF_Test.tcl
@@ -491,6 +491,16 @@ pfset Solver.Linear.Preconditioner.PCMatrixType     FullJacobian
 pfset NetCDF.NumStepsPerFile			5
 pfset NetCDF.WritePressure			True
 pfset NetCDF.WriteSaturation			True
+pfset NetCDF.WriteMannings			True
+pfset NetCDF.WriteSubsurface			True
+pfset NetCDF.WriteSlopes			True
+pfset NetCDF.WriteMask				True
+pfset NetCDF.WriteDZMultiplier			True
+pfset NetCDF.WriteEvapTrans			True
+pfset NetCDF.WriteEvapTransSum			True
+pfset NetCDF.WriteOverlandSum			True
+pfset NetCDF.WriteOverlandBCFlux			True
+pfset Solver.PrintOverlandBCFlux			True
 
 #-----------------------------------------------------------------------------
 # Distribute inputs


### PR DESCRIPTION
Hello Steve,
I have created this branch for additional ParFlow variables. Following variables can be written to a initial netcdf file.
At the initial time step(0), user can output following variables(initial pressure and saturation and static fields)
Pressure, Saturation, mannings coeff., permiability in x, y and z direction, porosity, specific storage, slopes in x and y directions, DZ multipliers, and mask.
From the next time step onwards in single netcdf files user can output following variabls,
pressure, saturation, evaptrans, evaptrans sum, overland sum and overland bc flux.
In all above mentioned variables, we have mix of 2D and 3D variables in one file.
All the relevant keys are documented in manual and Little Washita netcdf test case is updated.
Regards,
Ketan