### PR TITLE
Updated path for config install to be more consistent with CMake 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -352,4 +352,4 @@ endif ()
 #-----------------------------------------------------------------------------
 include (CTest)
 
-install (DIRECTORY ${CMAKE_BINARY_DIR}/config DESTINATION . )
+install (DIRECTORY ${CMAKE_BINARY_DIR}/config/ DESTINATION config)


### PR DESCRIPTION
Was using "." to get directory to install to root of installation prefix, CMake uses "/" appended to src directory name to prevent appending.   This avoids having a "/./" in path names.