### PR TITLE
PFMG Galerkin RAPType does not work with RedBlack options

### DIFF
--- a/pfsimulator/parflow_lib/pf_pfmg.c
+++ b/pfsimulator/parflow_lib/pf_pfmg.c
@@ -729,14 +729,14 @@ PFModule  *PFMGNewPublicXtra(char *name)
 
   /* Use a dummy place holder so that cardinalities match
    * with what HYPRE expects */
-  smoother_switch_na = NA_NewNameArray("Dummy Jacobi WJacobi RBGaussSeidelSymmetric RBGaussSeidelNonSymmetric");
+  smoother_switch_na = NA_NewNameArray("Jacobi WJacobi RBGaussSeidelSymmetric RBGaussSeidelNonSymmetric");
   sprintf(key, "%s.Smoother", name);
   smoother_name = GetStringDefault(key, "RBGaussSeidelNonSymmetric");
   smoother = NA_NameToIndex(smoother_switch_na, smoother_name);
-  if (smoother != 0)
+  if (smoother >= 0)
   {
     public_xtra->smoother = NA_NameToIndex(smoother_switch_na,
-                                           smoother_name) - 1;
+                                           smoother_name);
   }
   else
   {
@@ -755,10 +755,16 @@ PFModule  *PFMGNewPublicXtra(char *name)
   }
   else
   {
-    InputError("FOO Error: Invalid value <%s> for key <%s>.\n",
+    InputError("Error: Invalid value <%s> for key <%s>.\n",
                raptype_name, key);
   }
   NA_FreeNameArray(raptype_switch_na);
+
+  if(raptype == 0 && smoother > 1)
+  {
+     InputError("Error: Galerkin RAPType is not compatible with Smoother <%s>.\n",
+		smoother_name, key);
+  }
 
   public_xtra->time_index_pfmg = RegisterTiming("PFMG");
   public_xtra->time_index_copy_hypre = RegisterTiming("HYPRE_Copies");

--- a/test/pfmg.tcl
+++ b/test/pfmg.tcl
@@ -321,11 +321,12 @@ pfset Solver.Nonlinear.DerivativeEpsilon                 1e-2
 pfset Solver.Linear.KrylovDimension                      10
 
 pfset Solver.Linear.Preconditioner                       PFMG
+pfset Solver.Linear.Preconditioner.PFMG.Smoother         WJacobi
 
 #pfset Solver.Linear.Preconditioner.PFMG.MaxIter          1
 #pfset Solver.Linear.Preconditioner.PFMG.NumPreRelax      100
 #pfset Solver.Linear.Preconditioner.PFMG.NumPostRelax     100
-#pfset Solver.Linear.Preconditioner.PFMG.Smoother         100
+
 
 #-----------------------------------------------------------------------------
 # Run and Unload the ParFlow output files

--- a/test/pfmg_galerkin.tcl
+++ b/test/pfmg_galerkin.tcl
@@ -321,7 +321,7 @@ pfset Solver.Nonlinear.DerivativeEpsilon                 1e-2
 pfset Solver.Linear.KrylovDimension                      10
 
 pfset Solver.Linear.Preconditioner                       PFMG
-
+pfset Solver.Linear.Preconditioner.PFMG.Smoother         WJacobi
 pfset Solver.Linear.Preconditioner.PFMG.RAPType          Galerkin
 
 #-----------------------------------------------------------------------------


### PR DESCRIPTION
Add input check so Galerkin RAPTYPE choice will flag an error if red-black options are also used.
Fix example to use WJacobi with Galerkin.

