### PR TITLE
Find netcdf includes when netcdf was compiled using configure

### DIFF
--- a/pfsimulator/parflow_lib/CMakeLists.txt
+++ b/pfsimulator/parflow_lib/CMakeLists.txt
@@ -173,5 +173,6 @@ endif (${PARFLOW_HAVE_SILO})
 
 if (${PARFLOW_HAVE_NETCDF})
   target_include_directories (pfsimulator PUBLIC "${netCDF_INCLUDE_DIRS}")
+  target_include_directories (pfsimulator PUBLIC "${NETCDF_INCLUDE_DIRS}")
 endif (${PARFLOW_HAVE_NETCDF})
 


### PR DESCRIPTION
When using configure, netcdf will not install the cmake config files
that would be used to setup the header search paths (netCDF_INCLUDE_DIRS).
But parflows own FindNetCDF.cmake script sets **NET**CDF_INCLUDE_DIRS .