### PR TITLE
Fixed some small memory leaks and one premature deallocation

### DIFF
--- a/pftools/printdatabox.c
+++ b/pftools/printdatabox.c
@@ -725,17 +725,16 @@ void            PrintVTK(
     int j;
     double *DTd;
     float *DTf;
-    DTd = (double*)malloc(tools_SizeofDouble * nxyzp * 3);
     DTf = (float*)malloc(tools_SizeofFloat * nxyzp * 3);
     DTd = DataboxCoeffs(v);
     for (j = 0; j < (NX * NY * NZ); ++j)
     {
       DTf[j] = (float)DTd[j];
     }
-    free(DTd);
     fprintf(fp, "SCALARS %s float\n", varname);
     fprintf(fp, "LOOKUP_TABLE default\n");
     tools_WriteFloat(fp, DTf, NX * NY * NZ);
+    free(DTf);
   }
   else
   {
@@ -782,6 +781,7 @@ void            PrintTFG_VTK(
   }
   fprintf(fp, "POINTS %i float\n", nxyzp);
   tools_WriteFloat(fp, pnt, nxyzp * 3);
+  free(pnt);
 
 // COMMENT THE PREVIOUS 8 AND UNCOMMENT THE FOLLOWING 3 TO FORCE DOUBLE WRITE
 //        /* Write points as double */
@@ -798,7 +798,6 @@ void            PrintTFG_VTK(
     int j;
     double *DTd;
     float *DTf;
-    DTd = (double*)malloc(tools_SizeofDouble * nxyzp * 3);
     DTf = (float*)malloc(tools_SizeofFloat * nxyzp * 3);
     DTd = DataboxCoeffs(v);
 
@@ -810,6 +809,7 @@ void            PrintTFG_VTK(
     fprintf(fp, "SCALARS %s float\n", varname);
     fprintf(fp, "LOOKUP_TABLE default\n");
     tools_WriteFloat(fp, DTf, NX * NY * NZ);
+    free(DTf);
   }
   else
   {
@@ -877,7 +877,6 @@ void            PrintCLMVTK(
     double *DTd;
     float  *DTf;
     float  *val;
-    DTd = (double*)malloc(tools_SizeofDouble * nxyzp);
     DTf = (float*)malloc(tools_SizeofFloat * nxyzp);
     DTd = DataboxCoeffs(v);
     for (j = 0; j < (NX * NY * NZ); ++j)
@@ -915,6 +914,7 @@ void            PrintCLMVTK(
         }
       }
     }
+    free(DTf);
   }
   else
   {
@@ -1003,6 +1003,7 @@ void            PrintTFG_CLMVTK(
   }
   fprintf(fp, "POINTS %i float\n", nxyzp);
   tools_WriteFloat(fp, pnt, nxyzp * 3);
+  free(pnt);
 
   // COMMENT THE PREVIOUS 8 AND UNCOMMENT THE FOLLOWING 3 TO FORCE DOUBLE WRITE
   //        /* Write points as double */
@@ -1022,7 +1023,6 @@ void            PrintTFG_CLMVTK(
     double *DTd;
     float  *DTf;
     float  *val;
-    DTd = (double*)malloc(tools_SizeofDouble * nxyzp);
     DTf = (float*)malloc(tools_SizeofFloat * nxyzp);
     DTd = DataboxCoeffs(v);
     for (j = 0; j < (NX * NY * NZ); ++j)
@@ -1060,6 +1060,7 @@ void            PrintTFG_CLMVTK(
         }
       }
     }
+    free(DTf);
   }
   else
   {


### PR DESCRIPTION
Several functions in printdatabox.c appear to have small memory leaks. Several calls to malloc are missing an associated call to free. The variable DTd in several functions appears to be malloc'd and then assigned to a pre-existing allocated block of memory belonging to a Databox (which was already allocated).

In one case, DTd is freed after pointing to a block of memory owned by an existing Databox. This can create a double free error when attempting to call FreeDatabox on this Databox object. 

One other apparent issue that I just noticed (and didn't correct yet) is that DTf is allocated a much larger block of memory than it requires. The size should be NX*NY*NZ, not nxyzp*3.