### PR TITLE
Pass old pressure to overland flow evaluation methods

### DIFF
--- a/pfsimulator/parflow_lib/grgeometry.c
+++ b/pfsimulator/parflow_lib/grgeometry.c
@@ -310,7 +310,6 @@ GrGeomSolid   *GrGeomNewSolid(
 
   if(GlobalsUseClustering)
   {
-     printf("SGSDEBUG clustering\n");
      ComputeBoxes(new_grgeomsolid);
   }
 

--- a/pfsimulator/parflow_lib/kinsol_nonlin_solver.c
+++ b/pfsimulator/parflow_lib/kinsol_nonlin_solver.c
@@ -107,6 +107,7 @@ int  KINSolInitPC(
   ProblemData *problem_data = StateProblemData(((State*)current_state));
   Vector      *saturation = StateSaturation(((State*)current_state));
   Vector      *density = StateDensity(((State*)current_state));
+  Vector      *old_pressure = StateOldPressure(((State*)current_state));
   double dt = StateDt(((State*)current_state));
   double time = StateTime(((State*)current_state));
 
@@ -124,7 +125,7 @@ int  KINSolInitPC(
    * itself */
 
   PFModuleReNewInstanceType(KinsolPCInitInstanceXtraInvoke, precond, (NULL, NULL, problem_data, NULL,
-                                                                      pressure, saturation, density, dt, time));
+                                                                      pressure, old_pressure, saturation, density, dt, time));
   return(0);
 }
 
@@ -351,7 +352,7 @@ PFModule  *KinsolNonlinSolverInitInstanceXtra(
       instance_xtra->precond =
         PFModuleNewInstanceType(KinsolPCInitInstanceXtraInvoke, public_xtra->precond,
                                 (problem, grid, problem_data, temp_data,
-                                 NULL, NULL, NULL, 0, 0));
+                                 NULL, NULL, NULL, NULL, 0, 0));
     else
       instance_xtra->precond = NULL;
 
@@ -373,7 +374,7 @@ PFModule  *KinsolNonlinSolverInitInstanceXtra(
       PFModuleReNewInstanceType(KinsolPCInitInstanceXtraInvoke,
                                 instance_xtra->precond,
                                 (problem, grid, problem_data, temp_data,
-                                 NULL, NULL, NULL, 0, 0));
+                                 NULL, NULL, NULL, NULL, 0, 0));
 
     PFModuleReNewInstanceType(NlFunctionEvalInitInstanceXtraInvoke, instance_xtra->nl_function_eval,
                               (problem, grid, temp_data));

--- a/pfsimulator/parflow_lib/kinsol_pc.c
+++ b/pfsimulator/parflow_lib/kinsol_pc.c
@@ -88,6 +88,7 @@ PFModule  *KinsolPCInitInstanceXtra(
                                     ProblemData *problem_data,
                                     double *     temp_data,
                                     Vector *     pressure,
+				    Vector *     old_pressure,
                                     Vector *     saturation,
                                     Vector *     density,
                                     double       dt,
@@ -145,7 +146,7 @@ PFModule  *KinsolPCInitInstanceXtra(
   else if (pressure != NULL)
   {
     PFModuleInvokeType(RichardsJacobianEvalInvoke, (instance_xtra->discretization),
-                       (pressure, &PC, &JC, saturation, density, problem_data, dt,
+                       (pressure, old_pressure, &PC, &JC, saturation, density, problem_data, dt,
                         time, pc_matrix_type));
     PFModuleReNewInstanceType(PrecondInitInstanceXtraInvoke,
                               (instance_xtra->precond),

--- a/pfsimulator/parflow_lib/nl_function_eval.c
+++ b/pfsimulator/parflow_lib/nl_function_eval.c
@@ -1408,7 +1408,7 @@ void NlFunctionEval(Vector *     pressure, /* Current pressure values */
           if (diffusive == 0)
           {
             /* Call overlandflow_eval to compute fluxes across the east, west, north, and south faces */
-            PFModuleInvokeType(OverlandFlowEvalInvoke, overlandflow_module, (grid, is, bc_struct, ipatch, problem_data, pressure,
+            PFModuleInvokeType(OverlandFlowEvalInvoke, overlandflow_module, (grid, is, bc_struct, ipatch, problem_data, pressure, old_pressure,
                                                                              ke_, kw_, kn_, ks_, qx_, qy_, CALCFCN));
           }
           else
@@ -1416,7 +1416,7 @@ void NlFunctionEval(Vector *     pressure, /* Current pressure values */
             /*  @RMM this is modified to be kinematic wave routing, with a new module for diffusive wave
              * routing added */
             double *dummy1, *dummy2, *dummy3, *dummy4;
-            PFModuleInvokeType(OverlandFlowEvalDiffInvoke, overlandflow_module_diff, (grid, is, bc_struct, ipatch, problem_data, pressure,
+            PFModuleInvokeType(OverlandFlowEvalDiffInvoke, overlandflow_module_diff, (grid, is, bc_struct, ipatch, problem_data, pressure, old_pressure,
                                                                                       ke_, kw_, kn_, ks_,
                                                                                       dummy1, dummy2, dummy3, dummy4,
                                                                                       qx_, qy_, CALCFCN));

--- a/pfsimulator/parflow_lib/overlandflow_eval.c
+++ b/pfsimulator/parflow_lib/overlandflow_eval.c
@@ -58,6 +58,7 @@ void    OverlandFlowEval(
                          int          ipatch, /* current boundary patch */
                          ProblemData *problem_data, /* Geometry data for problem */
                          Vector *     pressure, /* Vector of phase pressures at each block */
+                         Vector *     old_pressure, /* Vector of phase pressures at previous time */
                          double *     ke_v, /* return array corresponding to the east face KE  */
                          double *     kw_v, /* return array corresponding to the west face KW */
                          double *     kn_v, /* return array corresponding to the north face KN */

--- a/pfsimulator/parflow_lib/overlandflow_eval_diffusive.c
+++ b/pfsimulator/parflow_lib/overlandflow_eval_diffusive.c
@@ -60,6 +60,7 @@ void    OverlandFlowEvalDiff(
                              int          ipatch, /* current boundary patch */
                              ProblemData *problem_data, /* Geometry data for problem */
                              Vector *     pressure, /* Vector of phase pressures at each block */
+			     Vector *     old_pressure, /* Vector of phase pressures at previous time */
                              double *     ke_v, /* return array corresponding to the east face KE  */
                              double *     kw_v, /* return array corresponding to the west face KW */
                              double *     kn_v, /* return array corresponding to the north face KN */

--- a/pfsimulator/parflow_lib/parflow_proto.h
+++ b/pfsimulator/parflow_lib/parflow_proto.h
@@ -331,12 +331,12 @@ void KinsolNonlinSolverFreePublicXtra(void);
 int KinsolNonlinSolverSizeOfTempData(void);
 
 typedef void (*KinsolPCInvoke) (Vector *rhs);
-typedef PFModule * (*KinsolPCInitInstanceXtraInvoke) (Problem *problem, Grid *grid, ProblemData *problem_data, double *temp_data, Vector *pressure, Vector *saturation, Vector *density, double dt, double time);
+typedef PFModule * (*KinsolPCInitInstanceXtraInvoke) (Problem *problem, Grid *grid, ProblemData *problem_data, double *temp_data, Vector *pressure, Vector *old_pressure, Vector *saturation, Vector *density, double dt, double time);
 typedef PFModule *(*KinsolPCNewPublicXtraInvoke) (char *name, char *pc_name);
 
 /* kinsol_pc.c */
 void KinsolPC(Vector *rhs);
-PFModule *KinsolPCInitInstanceXtra(Problem *problem, Grid *grid, ProblemData *problem_data, double *temp_data, Vector *pressure, Vector *saturation, Vector *density, double dt, double time);
+PFModule *KinsolPCInitInstanceXtra(Problem *problem, Grid *grid, ProblemData *problem_data, double *temp_data, Vector *pressure, Vector *old_pressure, Vector *saturation, Vector *density, double dt, double time);
 void KinsolPCFreeInstanceXtra(void);
 PFModule *KinsolPCNewPublicXtra(char *name, char *pc_name);
 void KinsolPCFreePublicXtra(void);
@@ -737,6 +737,7 @@ typedef void (*OverlandFlowEvalInvoke) (Grid *       grid,
                                         int          ipatch,
                                         ProblemData *problem_data,
                                         Vector *     pressure,
+                                        Vector *     old_pressure,
                                         double *     ke_v,
                                         double *     kw_v,
                                         double *     kn_v,
@@ -751,6 +752,7 @@ void OverlandFlowEval(Grid *       grid,
                       int          ipatch,
                       ProblemData *problem_data,
                       Vector *     pressure,
+                      Vector *     old_pressure,
                       double *     ke_v,
                       double *     kw_v,
                       double *     kn_v,
@@ -771,6 +773,7 @@ typedef void (*OverlandFlowEvalDiffInvoke) (Grid *       grid,
                                             int          ipatch,
                                             ProblemData *problem_data,
                                             Vector *     pressure,
+					    Vector *     old_pressure,
                                             double *     ke_v,
                                             double *     kw_v,
                                             double *     kn_v,
@@ -789,6 +792,7 @@ void OverlandFlowEvalDiff(Grid *       grid,
                           int          ipatch,
                           ProblemData *problem_data,
                           Vector *     pressure,
+			  Vector *     old_pressure,
                           double *     ke_v,
                           double *     kw_v,
                           double *     kn_v,
@@ -978,12 +982,12 @@ void DeleteSubregion(SubregionArray *sr_array, int index);
 void AppendSubregionArray(SubregionArray *sr_array_0, SubregionArray *sr_array_1);
 
 
-typedef void (*RichardsJacobianEvalInvoke) (Vector *pressure, Matrix **ptr_to_J, Matrix **ptr_to_JC, Vector *saturation, Vector *density, ProblemData *problem_data, double dt, double time, int symm_part);
+typedef void (*RichardsJacobianEvalInvoke) (Vector *pressure, Vector *old_pressure, Matrix **ptr_to_J, Matrix **ptr_to_JC, Vector *saturation, Vector *density, ProblemData *problem_data, double dt, double time, int symm_part);
 typedef PFModule *(*RichardsJacobianEvalInitInstanceXtraInvoke) (Problem *problem, Grid *grid, ProblemData *problem_data, double *temp_data, int symmetric_jac);
 typedef PFModule *(*RichardsJacobianEvalNewPublicXtraInvoke) (char *name);
 /* richards_jacobian_eval.c */
 int KINSolMatVec(void *current_state, N_Vector x, N_Vector y, int *recompute, N_Vector pressure);
-void RichardsJacobianEval(Vector *pressure, Matrix **ptr_to_J, Matrix **ptr_to_JC, Vector *saturation, Vector *density, ProblemData *problem_data, double dt, double time, int symm_part);
+void RichardsJacobianEval(Vector *pressure, Vector *old_pressure, Matrix **ptr_to_J, Matrix **ptr_to_JC, Vector *saturation, Vector *density, ProblemData *problem_data, double dt, double time, int symm_part);
 PFModule *RichardsJacobianEvalInitInstanceXtra(Problem *problem, Grid *grid, ProblemData *problem_data, double *temp_data, int symmetric_jac);
 void RichardsJacobianEvalFreeInstanceXtra(void);
 PFModule *RichardsJacobianEvalNewPublicXtra(char *name);

--- a/pfsimulator/parflow_lib/richards_jacobian_eval.c
+++ b/pfsimulator/parflow_lib/richards_jacobian_eval.c
@@ -141,6 +141,7 @@ int       KINSolMatVec(
   PFModule    *richards_jacobian_eval = StateJacEval(((State*)current_state));
   Matrix      *J = StateJac(((State*)current_state));
   Matrix      *JC = StateJacC(((State*)current_state));
+  Vector      *old_pressure = StateOldPressure(((State*)current_state));
   Vector      *saturation = StateSaturation(((State*)current_state));
   Vector      *density = StateDensity(((State*)current_state));
   ProblemData *problem_data = StateProblemData(((State*)current_state));
@@ -161,7 +162,7 @@ int       KINSolMatVec(
   if (*recompute)
   {
     PFModuleInvokeType(RichardsJacobianEvalInvoke, richards_jacobian_eval,
-                       (pressure, &J, &JC, saturation, density, problem_data,
+                       (pressure, old_pressure, &J, &JC, saturation, density, problem_data,
                         dt, time, 0));
 
     *recompute = 0;
@@ -183,6 +184,7 @@ int       KINSolMatVec(
 
 void    RichardsJacobianEval(
                              Vector *     pressure, /* Current pressure values */
+			     Vector *     old_pressure, /* Pressure values at previous timestep */
                              Matrix **    ptr_to_J, /* Pointer to the J pointer - this will be set
                                                      * to instance_xtra pointer at end */
                              Matrix **    ptr_to_JC, /* Pointer to the JC pointer - this will be set
@@ -1267,7 +1269,7 @@ void    RichardsJacobianEval(
                 if (diffusive == 0)
                 {
                   PFModuleInvokeType(OverlandFlowEvalInvoke, overlandflow_module,
-                                     (grid, is, bc_struct, ipatch, problem_data, pressure,
+                                     (grid, is, bc_struct, ipatch, problem_data, pressure, old_pressure,
                                       ke_der, kw_der, kn_der, ks_der, NULL, NULL, CALCDER));
                 }
                 else
@@ -1280,7 +1282,7 @@ void    RichardsJacobianEval(
                   //                                                    NULL, NULL, CALCFCN));
 
                   PFModuleInvokeType(OverlandFlowEvalDiffInvoke, overlandflow_module_diff,
-                                     (grid, is, bc_struct, ipatch, problem_data, pressure,
+                                     (grid, is, bc_struct, ipatch, problem_data, pressure, old_pressure,
                                       ke_der, kw_der, kn_der, ks_der,
                                       kens_der, kwns_der, knns_der, ksns_der, NULL, NULL, CALCDER));
                 }


### PR DESCRIPTION
Overland flow improvements require access to the previous pressure.   Added old pressure to the overland flow module interfaces.

Closes #152 