### PR TITLE
Temporary initializer arrays should have fixed size 

### DIFF
--- a/pfsimulator/clm/drv_clmini.F90
+++ b/pfsimulator/clm/drv_clmini.F90
@@ -72,8 +72,8 @@ subroutine drv_clmini (drv, grid, tile, clm, istep_pf)
   integer  i, j, L           !loop indices
   real(r8) bd                !bulk density of dry soil material [kg/m^3]
   real(r8) tkm               !mineral conductivity
-  real(r8) zlak(1:nlevlak)   !temporary z
-  real(r8) dzlak(1:nlevlak)  !temporary dz
+  real(r8) zlak(1:10)   !temporary z; currenly hard coded initialization
+  real(r8) dzlak(1:10)  !temporary dz; currenly hard coded initialization
   real(r8) xksat
 
 !=== End Variable List ===================================================


### PR DESCRIPTION
Two arrays are used to hold initial values; should be fixed size and not based on soil/lake levels from user input to avoid array bounds issues.

Fixes #151 
