### PR TITLE
Bugfix itop

### DIFF
--- a/pfsimulator/parflow_lib/overlandflow_eval_Kin.c
+++ b/pfsimulator/parflow_lib/overlandflow_eval_Kin.c
@@ -131,8 +131,10 @@ void    OverlandFlowEvalKin(
         k1 = (int)top_dat[itop];
         k0x = (int)top_dat[itop - 1];
         k0y = (int)top_dat[itop - sy_v];
-        k1x = (int)top_dat[itop + 1];
-        k1y = (int)top_dat[itop + sy_v];
+        k1x = pfmax((int)top_dat[itop + 1],0);
+        k1y = pfmax((int)top_dat[itop + sy_v],0);
+        printf("i=%d j=%d k1=%d k1x=%d k1y=%d \n",i,j,k1,k1x,k1y);
+
 
         if (k1 >= 0)
         {
@@ -140,7 +142,7 @@ void    OverlandFlowEvalKin(
           Sf_x = sx_dat[io];
           Sf_y = sy_dat[io];
           ipp1 = (int)SubvectorEltIndex(p_sub, i+1, j, k1x);
-          ippsy = (int)SubvectorEltIndex(p_sub, i, j+sy_v, k1y);
+          ippsy = (int)SubvectorEltIndex(p_sub, i, j+1, k1y);
 
           Sf_mag = RPowerR(Sf_x * Sf_x + Sf_y * Sf_y, 0.5);
           if (Sf_mag < ov_epsilon)
@@ -206,7 +208,6 @@ void    OverlandFlowEvalKin(
         kw_v[io] = qx_v[io - 1];
         kn_v[io] = qy_v[io];
         ks_v[io] = qy_v[io - sy_v];
-        //printf("i=%d j=%d k=%d ke_v=%d kw_v=%d kn_v=%d ks_v=%f\n",i,j,k,ke_v[io],kw_v[io],kn_v[io],ks_v[io]);
       }
     });
   }
@@ -229,7 +230,7 @@ void    OverlandFlowEvalKin(
         {
           ip = SubvectorEltIndex(p_sub, i, j, k1);
           ipp1 = (int)SubvectorEltIndex(p_sub, i+1, j, k1x);
-          ippsy = (int)SubvectorEltIndex(p_sub, i, j+sy_v, k1y);
+          ippsy = (int)SubvectorEltIndex(p_sub, i, j+1, k1y);
 
           Sf_x = sx_dat[io];
           Sf_y = sy_dat[io];

--- a/pfsimulator/parflow_lib/overlandflow_eval_Kin.c
+++ b/pfsimulator/parflow_lib/overlandflow_eval_Kin.c
@@ -70,7 +70,6 @@ void    OverlandFlowEvalKin(
   Vector      *mannings = ProblemDataMannings(problem_data);
   Vector      *top = ProblemDataIndexOfDomainTop(problem_data);
 
-  // printf("overland_eval_diffusive called\n");
   Subvector     *sx_sub, *sy_sub, *mann_sub, *top_sub, *p_sub;
 
   Subgrid      *subgrid;
@@ -133,8 +132,6 @@ void    OverlandFlowEvalKin(
         k0y = (int)top_dat[itop - sy_v];
         k1x = pfmax((int)top_dat[itop + 1],0);
         k1y = pfmax((int)top_dat[itop + sy_v],0);
-        printf("i=%d j=%d k1=%d k1x=%d k1y=%d \n",i,j,k1,k1x,k1y);
-
 
         if (k1 >= 0)
         {

--- a/pfsimulator/parflow_lib/overlandflow_eval_Kin.c
+++ b/pfsimulator/parflow_lib/overlandflow_eval_Kin.c
@@ -19,7 +19,7 @@
 *  kinematic wave approximation for the overland flow boundary condition:KE,KW,KN,KS.
 *
 *  It also computes the derivatives of these terms for inclusion in the Jacobian.
-
+*
 * @LEC, @RMM
 *****************************************************************************/
 #include "parflow.h"
@@ -42,23 +42,23 @@ typedef void InstanceXtra;
  *-------------------------------------------------------------------------*/
 
 void    OverlandFlowEvalKin(
-                             Grid *       grid, /* data struct for computational grid */
-                             int          sg, /* current subgrid */
-                             BCStruct *   bc_struct, /* data struct of boundary patch values */
-                             int          ipatch, /* current boundary patch */
-                             ProblemData *problem_data, /* Geometry data for problem */
-                             Vector *     pressure, /* Vector of phase pressures at each block */
-                             double *     ke_v, /* return array corresponding to the east face KE  */
-                             double *     kw_v, /* return array corresponding to the west face KW */
-                             double *     kn_v, /* return array corresponding to the north face KN */
-                             double *     ks_v, /* return array corresponding to the south face KS */
-                             double *     ke_vns, /* return array corresponding to the nonsymetric east face KE derivative  */
-                             double *     kw_vns, /* return array corresponding to the nonsymetricwest face KW derivative */
-                             double *     kn_vns, /* return array corresponding to the nonsymetricnorth face KN derivative */
-                             double *     ks_vns, /* return array corresponding to the nonsymetricsouth face KS derivative*/
-                             double *     qx_v, /* return array corresponding to the flux in x-dir */
-                             double *     qy_v, /* return array corresponding to the flux in y-dir */
-                             int          fcn) /* Flag determining what to calculate
+                            Grid *       grid,  /* data struct for computational grid */
+                            int          sg,  /* current subgrid */
+                            BCStruct *   bc_struct,  /* data struct of boundary patch values */
+                            int          ipatch,  /* current boundary patch */
+                            ProblemData *problem_data,  /* Geometry data for problem */
+                            Vector *     pressure,  /* Vector of phase pressures at each block */
+                            double *     ke_v,  /* return array corresponding to the east face KE  */
+                            double *     kw_v,  /* return array corresponding to the west face KW */
+                            double *     kn_v,  /* return array corresponding to the north face KN */
+                            double *     ks_v,  /* return array corresponding to the south face KS */
+                            double *     ke_vns,  /* return array corresponding to the nonsymetric east face KE derivative  */
+                            double *     kw_vns,  /* return array corresponding to the nonsymetricwest face KW derivative */
+                            double *     kn_vns,  /* return array corresponding to the nonsymetricnorth face KN derivative */
+                            double *     ks_vns,  /* return array corresponding to the nonsymetricsouth face KS derivative*/
+                            double *     qx_v,  /* return array corresponding to the flux in x-dir */
+                            double *     qy_v,  /* return array corresponding to the flux in y-dir */
+                            int          fcn)  /* Flag determining what to calculate
                                                 * fcn = CALCFCN => calculate the function value
                                                 * fcn = CALCDER => calculate the function
                                                 *                  derivative */
@@ -121,7 +121,6 @@ void    OverlandFlowEvalKin(
 
   if (fcn == CALCFCN)
   {
-
     BCStructPatchLoopOvrlnd(i, j, k, fdir, ival, bc_struct, ipatch, sg,
     {
       if (fdir[2] == 1)
@@ -135,70 +134,67 @@ void    OverlandFlowEvalKin(
         k1x = (int)top_dat[itop + 1];
         k1y = (int)top_dat[itop + sy_v];
 
-//        printf("i=%d j=%d k=%d \n",i,j,k1);
-
-
         if (k1 >= 0)
         {
           ip = SubvectorEltIndex(p_sub, i, j, k1);
-          ipp1 = (int)SubvectorEltIndex(p_sub, i+1, j, k1x);
-          ippsy = (int)SubvectorEltIndex(p_sub, i, j+sy_v, k1y);
-//          printf("ip=%d \n",ip);
           Sf_x = sx_dat[io];
           Sf_y = sy_dat[io];
+          ipp1 = (int)SubvectorEltIndex(p_sub, i+1, j, k1x);
+          ippsy = (int)SubvectorEltIndex(p_sub, i, j+sy_v, k1y);
 
-          Sf_mag = RPowerR(Sf_x*Sf_x+Sf_y*Sf_y,0.5);
+          Sf_mag = RPowerR(Sf_x * Sf_x + Sf_y * Sf_y, 0.5);
           if (Sf_mag < ov_epsilon)
-          Sf_mag = ov_epsilon;
+            Sf_mag = ov_epsilon;
 
           Press_x = RPMean(-Sf_x, 0.0, pfmax((pp[ip]), 0.0), pfmax((pp[ipp1]), 0.0));
           Press_y = RPMean(-Sf_y, 0.0, pfmax((pp[ip]), 0.0), pfmax((pp[ippsy]), 0.0));
 
-          qx_v[io] = -(Sf_x / (RPowerR(fabs(Sf_mag),0.5)*mann_dat[io])) * RPowerR(Press_x, (5.0 / 3.0));
-          qy_v[io] = -(Sf_y / (RPowerR(fabs(Sf_mag),0.5)*mann_dat[io])) * RPowerR(Press_y, (5.0 / 3.0));
-
-
+          qx_v[io] = -(Sf_x / (RPowerR(fabs(Sf_mag), 0.5) * mann_dat[io])) * RPowerR(Press_x, (5.0 / 3.0));
+          qy_v[io] = -(Sf_y / (RPowerR(fabs(Sf_mag), 0.5) * mann_dat[io])) * RPowerR(Press_y, (5.0 / 3.0));
         }
 
         //fix for lower x boundary
-        if (k0x < 0.0) {
-            if (k1 >= 0.0) {
-              Sf_x = sx_dat[io];
-              Sf_y = sy_dat[io];
-//              printf("BCx i=%d j=%d k=%d \n",i,j,k1);
+        if (k0x < 0.0)
+        {
+          if (k1 >= 0.0)
+          {
+            Sf_x = sx_dat[io];
+            Sf_y = sy_dat[io];
 
-              double Sf_mag = RPowerR(Sf_x*Sf_x+Sf_y*Sf_y,0.5);
-              if (Sf_mag < ov_epsilon)
+            double Sf_mag = RPowerR(Sf_x * Sf_x + Sf_y * Sf_y, 0.5);
+            if (Sf_mag < ov_epsilon)
               Sf_mag = ov_epsilon;
 
-              if (Sf_x > 0.0) {
-                ip = SubvectorEltIndex(p_sub, i, j, k1);
-                Press_x = pfmax((pp[ip]), 0.0);
-                qx_v[io-1] = -(Sf_x / (RPowerR(fabs(Sf_mag),0.5)*mann_dat[io])) * RPowerR(Press_x, (5.0 / 3.0));
-              }
+            if (Sf_x > 0.0)
+            {
+              ip = SubvectorEltIndex(p_sub, i, j, k1);
+              Press_x = pfmax((pp[ip]), 0.0);
+              qx_v[io - 1] = -(Sf_x / (RPowerR(fabs(Sf_mag), 0.5) * mann_dat[io])) * RPowerR(Press_x, (5.0 / 3.0));
             }
           }
+        }
 
-          //fix for lower y boundary
-          if (k0y < 0.0) {
-              if (k1 >= 0.0) {
-              //  printf("BCy i=%d j=%d k=%d \n",i,j,k1);
+        //fix for lower y boundary
+        if (k0y < 0.0)
+        {
+          if (k1 >= 0.0)
+          {
+            Sf_x = sx_dat[io];
+            Sf_y = sy_dat[io];
 
-                Sf_x = sx_dat[io];
-                Sf_y = sy_dat[io];
+            double Sf_mag = RPowerR(Sf_x * Sf_x + Sf_y * Sf_y, 0.5);
+            if (Sf_mag < ov_epsilon)
+              Sf_mag = ov_epsilon;
 
-                double Sf_mag = RPowerR(Sf_x*Sf_x+Sf_y*Sf_y,0.5);
-                if (Sf_mag < ov_epsilon)
-                Sf_mag = ov_epsilon;
-
-                if (Sf_y > 0.0) {
-                  ip = SubvectorEltIndex(p_sub, i, j, k1);
-                  Press_y = pfmax((pp[ip]), 0.0);
-                  qy_v[io-sy_v] = -(Sf_y / (RPowerR(fabs(Sf_mag),0.5)*mann_dat[io])) * RPowerR(Press_y, (5.0 / 3.0));
-                }
-              }
+            if (Sf_y > 0.0)
+            {
+              ip = SubvectorEltIndex(p_sub, i, j, k1);
+              Press_y = pfmax((pp[ip]), 0.0);
+              qy_v[io - sy_v] = -(Sf_y / (RPowerR(fabs(Sf_mag), 0.5) * mann_dat[io])) * RPowerR(Press_y, (5.0 / 3.0));
             }
-       }
+          }
+        }
+      }
     });
 
     BCStructPatchLoop(i, j, k, fdir, ival, bc_struct, ipatch, sg,
@@ -207,105 +203,104 @@ void    OverlandFlowEvalKin(
       {
         io = SubvectorEltIndex(sx_sub, i, j, 0);
         ke_v[io] = qx_v[io];
-        kw_v[io] = qx_v[io-1];
+        kw_v[io] = qx_v[io - 1];
         kn_v[io] = qy_v[io];
-        ks_v[io] = qy_v[io-sy_v];
+        ks_v[io] = qy_v[io - sy_v];
         //printf("i=%d j=%d k=%d ke_v=%d kw_v=%d kn_v=%d ks_v=%f\n",i,j,k,ke_v[io],kw_v[io],kn_v[io],ks_v[io]);
       }
     });
-
   }
   else          //fcn = CALCDER calculates the derivs
   {
+    BCStructPatchLoopOvrlnd(i, j, k, fdir, ival, bc_struct, ipatch, sg,
+    {
+      if (fdir[2] == 1)
+      {
+        io = SubvectorEltIndex(sx_sub, i, j, 0);
+        itop = SubvectorEltIndex(top_sub, i, j, 0);
 
-        BCStructPatchLoopOvrlnd(i, j, k, fdir, ival, bc_struct, ipatch, sg,
+        k1 = (int)top_dat[itop];
+        k0x = (int)top_dat[itop - 1];
+        k0y = (int)top_dat[itop - sy_v];
+        k1x = (int)top_dat[itop + 1];
+        k1y = (int)top_dat[itop + sy_v];
+
+        if (k1 >= 0)
         {
+          ip = SubvectorEltIndex(p_sub, i, j, k1);
+          ipp1 = (int)SubvectorEltIndex(p_sub, i+1, j, k1x);
+          ippsy = (int)SubvectorEltIndex(p_sub, i, j+sy_v, k1y);
 
-          if (fdir[2] == 1)
+          Sf_x = sx_dat[io];
+          Sf_y = sy_dat[io];
+
+          Sf_mag = RPowerR(Sf_x * Sf_x + Sf_y * Sf_y, 0.5);
+          if (Sf_mag < ov_epsilon)
+            Sf_mag = ov_epsilon;
+
+          Press_x = RPMean(-Sf_x, 0.0, pfmax((pp[ip]), 0.0), pfmax((pp[ipp1]), 0.0));
+          Press_y = RPMean(-Sf_y, 0.0, pfmax((pp[ip]), 0.0), pfmax((pp[ippsy]), 0.0));
+
+          qx_temp = -(5.0 / 3.0) * (Sf_x / (RPowerR(fabs(Sf_mag), 0.5) * mann_dat[io])) * RPowerR(Press_x, (2.0 / 3.0));
+          qy_temp = -(5.0 / 3.0) * (Sf_y / (RPowerR(fabs(Sf_mag), 0.5) * mann_dat[io])) * RPowerR(Press_y, (2.0 / 3.0));
+
+          ke_v[io] = pfmax(qx_temp, 0);
+          kw_v[io + 1] = -pfmax(-qx_temp, 0);
+          kn_v[io] = pfmax(qy_temp, 0);
+          ks_v[io + sy_v] = -pfmax(-qy_temp, 0);
+        }
+
+        //fix for lower x boundary
+        if (k0x < 0.0)
+        {
+          if (k1 >= 0.0)
           {
+            Sf_x = sx_dat[io];
+            Sf_y = sy_dat[io];
 
-            io = SubvectorEltIndex(sx_sub, i, j, 0);
-            itop = SubvectorEltIndex(top_sub, i, j, 0);
-
-            k1 = (int)top_dat[itop];
-            k0x = (int)top_dat[itop - 1];
-            k0y = (int)top_dat[itop - sy_v];
-            k1x = (int)top_dat[itop + 1];
-            k1y = (int)top_dat[itop + sy_v];
-
-            if (k1 >= 0)
-            {
-              ip = SubvectorEltIndex(p_sub, i, j, k1);
-              ipp1 = (int)SubvectorEltIndex(p_sub, i+1, j, k1x);
-              ippsy = (int)SubvectorEltIndex(p_sub, i, j+sy_v, k1y);
-              Sf_x = sx_dat[io];
-              Sf_y = sy_dat[io];
-
-             Sf_mag = RPowerR(Sf_x*Sf_x+Sf_y*Sf_y,0.5);
-              if (Sf_mag < ov_epsilon)
+            double Sf_mag = RPowerR(Sf_x * Sf_x + Sf_y * Sf_y, 0.5);
+            if (Sf_mag < ov_epsilon)
               Sf_mag = ov_epsilon;
 
-              Press_x = RPMean(-Sf_x, 0.0, pfmax((pp[ip]), 0.0), pfmax((pp[ipp1]), 0.0));
-              Press_y = RPMean(-Sf_y, 0.0, pfmax((pp[ip]), 0.0),pfmax((pp[ippsy]), 0.0));
+            if (Sf_x > 0.0)
+            {
+              ip = SubvectorEltIndex(p_sub, i, j, k1);
+              Press_x = pfmax((pp[ip]), 0.0);
+              qx_temp = -(5.0 / 3.0) * (Sf_x / (RPowerR(fabs(Sf_mag), 0.5) * mann_dat[io])) * RPowerR(Press_x, (2.0 / 3.0));
 
-              qx_temp = -(5.0/3.0)*(Sf_x / (RPowerR(fabs(Sf_mag),0.5)*mann_dat[io])) * RPowerR(Press_x, (2.0 / 3.0));
-              qy_temp = -(5.0/3.0)*(Sf_y / (RPowerR(fabs(Sf_mag),0.5)*mann_dat[io])) * RPowerR(Press_y, (2.0 / 3.0));
-
-              ke_v[io] = pfmax(qx_temp,0);
-              kw_v[io+1] =-pfmax(-qx_temp,0);
-              kn_v[io] = pfmax(qy_temp,0);
-              ks_v[io+sy_v] = -pfmax(-qy_temp,0);
-
+              kw_v[io] = qx_temp;
+              ke_v[io - 1] = qx_temp;
             }
-
-            //fix for lower x boundary
-            if (k0x < 0.0) {
-                if (k1 >= 0.0) {
-                  Sf_x = sx_dat[io];
-                  Sf_y = sy_dat[io];
-
-                  double Sf_mag = RPowerR(Sf_x*Sf_x+Sf_y*Sf_y,0.5);
-                  if (Sf_mag < ov_epsilon)
-                  Sf_mag = ov_epsilon;
-
-                  if (Sf_x > 0.0) {
-                    ip = SubvectorEltIndex(p_sub, i, j, k1);
-                    Press_x = pfmax((pp[ip]), 0.0);
-                  qx_temp = -(5.0/3.0)*(Sf_x / (RPowerR(fabs(Sf_mag),0.5)*mann_dat[io])) * RPowerR(Press_x, (2.0 / 3.0));
-
-                    kw_v[io] = qx_temp;
-                    ke_v[io-1] = qx_temp;
-                  }
-                }
-              }
-
-              //fix for lower y boundary
-              if (k0y < 0.0) {
-                  if (k1 >= 0.0) {
-
-                    Sf_x = sx_dat[io];
-                    Sf_y = sy_dat[io];
-
-                    double Sf_mag = RPowerR(Sf_x*Sf_x+Sf_y*Sf_y,0.5); //+ov_epsilon;
-                    if (Sf_mag < ov_epsilon)
-                    Sf_mag = ov_epsilon;
-
-                    if (Sf_y > 0.0) {
-                      ip = SubvectorEltIndex(p_sub, i, j, k1);
-                      Press_y = pfmax((pp[ip]), 0.0);
-                    qy_temp = -(5.0/3.0)*(Sf_y / (RPowerR(fabs(Sf_mag),0.5)*mann_dat[io])) * RPowerR(Press_y, (2.0 / 3.0));
-
-                    ks_v[io] = qy_temp;
-                    kn_v[io-sy_v] = qy_temp;
-                    }
-                  }
-                }
           }
-        });
+        }
 
-    } // else calcder
+        //fix for lower y boundary
+        if (k0y < 0.0)
+        {
+          if (k1 >= 0.0)
+          {
+            Sf_x = sx_dat[io];
+            Sf_y = sy_dat[io];
 
-  }   // function
+            double Sf_mag = RPowerR(Sf_x * Sf_x + Sf_y * Sf_y, 0.5);  //+ov_epsilon;
+            if (Sf_mag < ov_epsilon)
+              Sf_mag = ov_epsilon;
+
+            if (Sf_y > 0.0)
+            {
+              ip = SubvectorEltIndex(p_sub, i, j, k1);
+              Press_y = pfmax((pp[ip]), 0.0);
+              qy_temp = -(5.0 / 3.0) * (Sf_y / (RPowerR(fabs(Sf_mag), 0.5) * mann_dat[io])) * RPowerR(Press_y, (2.0 / 3.0));
+
+              ks_v[io] = qy_temp;
+              kn_v[io - sy_v] = qy_temp;
+            }
+          }
+        }
+      }
+    });
+  }   // else calcder
+}     // function
 
 
 //*/

--- a/pfsimulator/parflow_lib/overlandflow_eval_Kin.c
+++ b/pfsimulator/parflow_lib/overlandflow_eval_Kin.c
@@ -19,7 +19,7 @@
 *  kinematic wave approximation for the overland flow boundary condition:KE,KW,KN,KS.
 *
 *  It also computes the derivatives of these terms for inclusion in the Jacobian.
-*
+
 * @LEC, @RMM
 *****************************************************************************/
 #include "parflow.h"
@@ -42,23 +42,23 @@ typedef void InstanceXtra;
  *-------------------------------------------------------------------------*/
 
 void    OverlandFlowEvalKin(
-                            Grid *       grid,  /* data struct for computational grid */
-                            int          sg,  /* current subgrid */
-                            BCStruct *   bc_struct,  /* data struct of boundary patch values */
-                            int          ipatch,  /* current boundary patch */
-                            ProblemData *problem_data,  /* Geometry data for problem */
-                            Vector *     pressure,  /* Vector of phase pressures at each block */
-                            double *     ke_v,  /* return array corresponding to the east face KE  */
-                            double *     kw_v,  /* return array corresponding to the west face KW */
-                            double *     kn_v,  /* return array corresponding to the north face KN */
-                            double *     ks_v,  /* return array corresponding to the south face KS */
-                            double *     ke_vns,  /* return array corresponding to the nonsymetric east face KE derivative  */
-                            double *     kw_vns,  /* return array corresponding to the nonsymetricwest face KW derivative */
-                            double *     kn_vns,  /* return array corresponding to the nonsymetricnorth face KN derivative */
-                            double *     ks_vns,  /* return array corresponding to the nonsymetricsouth face KS derivative*/
-                            double *     qx_v,  /* return array corresponding to the flux in x-dir */
-                            double *     qy_v,  /* return array corresponding to the flux in y-dir */
-                            int          fcn)  /* Flag determining what to calculate
+                             Grid *       grid, /* data struct for computational grid */
+                             int          sg, /* current subgrid */
+                             BCStruct *   bc_struct, /* data struct of boundary patch values */
+                             int          ipatch, /* current boundary patch */
+                             ProblemData *problem_data, /* Geometry data for problem */
+                             Vector *     pressure, /* Vector of phase pressures at each block */
+                             double *     ke_v, /* return array corresponding to the east face KE  */
+                             double *     kw_v, /* return array corresponding to the west face KW */
+                             double *     kn_v, /* return array corresponding to the north face KN */
+                             double *     ks_v, /* return array corresponding to the south face KS */
+                             double *     ke_vns, /* return array corresponding to the nonsymetric east face KE derivative  */
+                             double *     kw_vns, /* return array corresponding to the nonsymetricwest face KW derivative */
+                             double *     kn_vns, /* return array corresponding to the nonsymetricnorth face KN derivative */
+                             double *     ks_vns, /* return array corresponding to the nonsymetricsouth face KS derivative*/
+                             double *     qx_v, /* return array corresponding to the flux in x-dir */
+                             double *     qy_v, /* return array corresponding to the flux in y-dir */
+                             int          fcn) /* Flag determining what to calculate
                                                 * fcn = CALCFCN => calculate the function value
                                                 * fcn = CALCDER => calculate the function
                                                 *                  derivative */
@@ -89,7 +89,7 @@ void    OverlandFlowEvalKin(
   int ival, sy_v, step;
   int            *fdir;
 
-  int i, ii, j, k, ip, ip2, ip3, ip4, ip0, io, itop;
+  int i, ii, j, k, ip, ip2, ip3, ip4, ip0, io, itop, k1x, k1y, ipp1, ippsy;
   int i1, j1, k1, k0x, k0y, iojm1, iojp1, ioip1, ioim1;
   /* @RMM get grid from global (assuming this is comp grid) to pass to CLM */
   int gnx = BackgroundNX(GlobalsBackground);
@@ -121,6 +121,7 @@ void    OverlandFlowEvalKin(
 
   if (fcn == CALCFCN)
   {
+
     BCStructPatchLoopOvrlnd(i, j, k, fdir, ival, bc_struct, ipatch, sg,
     {
       if (fdir[2] == 1)
@@ -131,66 +132,73 @@ void    OverlandFlowEvalKin(
         k1 = (int)top_dat[itop];
         k0x = (int)top_dat[itop - 1];
         k0y = (int)top_dat[itop - sy_v];
+        k1x = (int)top_dat[itop + 1];
+        k1y = (int)top_dat[itop + sy_v];
+
+//        printf("i=%d j=%d k=%d \n",i,j,k1);
+
 
         if (k1 >= 0)
         {
           ip = SubvectorEltIndex(p_sub, i, j, k1);
+          ipp1 = (int)SubvectorEltIndex(p_sub, i+1, j, k1x);
+          ippsy = (int)SubvectorEltIndex(p_sub, i, j+sy_v, k1y);
+//          printf("ip=%d \n",ip);
           Sf_x = sx_dat[io];
           Sf_y = sy_dat[io];
 
-          Sf_mag = RPowerR(Sf_x * Sf_x + Sf_y * Sf_y, 0.5);
+          Sf_mag = RPowerR(Sf_x*Sf_x+Sf_y*Sf_y,0.5);
           if (Sf_mag < ov_epsilon)
-            Sf_mag = ov_epsilon;
+          Sf_mag = ov_epsilon;
 
-          Press_x = RPMean(-Sf_x, 0.0, pfmax((pp[ip]), 0.0), pfmax((pp[ip + 1]), 0.0));
-          Press_y = RPMean(-Sf_y, 0.0, pfmax((pp[ip]), 0.0), pfmax((pp[ip + sy_v]), 0.0));
+          Press_x = RPMean(-Sf_x, 0.0, pfmax((pp[ip]), 0.0), pfmax((pp[ipp1]), 0.0));
+          Press_y = RPMean(-Sf_y, 0.0, pfmax((pp[ip]), 0.0), pfmax((pp[ippsy]), 0.0));
 
-          qx_v[io] = -(Sf_x / (RPowerR(fabs(Sf_mag), 0.5) * mann_dat[io])) * RPowerR(Press_x, (5.0 / 3.0));
-          qy_v[io] = -(Sf_y / (RPowerR(fabs(Sf_mag), 0.5) * mann_dat[io])) * RPowerR(Press_y, (5.0 / 3.0));
+          qx_v[io] = -(Sf_x / (RPowerR(fabs(Sf_mag),0.5)*mann_dat[io])) * RPowerR(Press_x, (5.0 / 3.0));
+          qy_v[io] = -(Sf_y / (RPowerR(fabs(Sf_mag),0.5)*mann_dat[io])) * RPowerR(Press_y, (5.0 / 3.0));
+
+
         }
 
         //fix for lower x boundary
-        if (k0x < 0.0)
-        {
-          if (k1 >= 0.0)
-          {
-            Sf_x = sx_dat[io];
-            Sf_y = sy_dat[io];
+        if (k0x < 0.0) {
+            if (k1 >= 0.0) {
+              Sf_x = sx_dat[io];
+              Sf_y = sy_dat[io];
+//              printf("BCx i=%d j=%d k=%d \n",i,j,k1);
 
-            double Sf_mag = RPowerR(Sf_x * Sf_x + Sf_y * Sf_y, 0.5);
-            if (Sf_mag < ov_epsilon)
+              double Sf_mag = RPowerR(Sf_x*Sf_x+Sf_y*Sf_y,0.5);
+              if (Sf_mag < ov_epsilon)
               Sf_mag = ov_epsilon;
 
-            if (Sf_x > 0.0)
-            {
-              ip = SubvectorEltIndex(p_sub, i, j, k1);
-              Press_x = pfmax((pp[ip]), 0.0);
-              qx_v[io - 1] = -(Sf_x / (RPowerR(fabs(Sf_mag), 0.5) * mann_dat[io])) * RPowerR(Press_x, (5.0 / 3.0));
+              if (Sf_x > 0.0) {
+                ip = SubvectorEltIndex(p_sub, i, j, k1);
+                Press_x = pfmax((pp[ip]), 0.0);
+                qx_v[io-1] = -(Sf_x / (RPowerR(fabs(Sf_mag),0.5)*mann_dat[io])) * RPowerR(Press_x, (5.0 / 3.0));
+              }
             }
           }
-        }
 
-        //fix for lower y boundary
-        if (k0y < 0.0)
-        {
-          if (k1 >= 0.0)
-          {
-            Sf_x = sx_dat[io];
-            Sf_y = sy_dat[io];
+          //fix for lower y boundary
+          if (k0y < 0.0) {
+              if (k1 >= 0.0) {
+              //  printf("BCy i=%d j=%d k=%d \n",i,j,k1);
 
-            double Sf_mag = RPowerR(Sf_x * Sf_x + Sf_y * Sf_y, 0.5);
-            if (Sf_mag < ov_epsilon)
-              Sf_mag = ov_epsilon;
+                Sf_x = sx_dat[io];
+                Sf_y = sy_dat[io];
 
-            if (Sf_y > 0.0)
-            {
-              ip = SubvectorEltIndex(p_sub, i, j, k1);
-              Press_y = pfmax((pp[ip]), 0.0);
-              qy_v[io - sy_v] = -(Sf_y / (RPowerR(fabs(Sf_mag), 0.5) * mann_dat[io])) * RPowerR(Press_y, (5.0 / 3.0));
+                double Sf_mag = RPowerR(Sf_x*Sf_x+Sf_y*Sf_y,0.5);
+                if (Sf_mag < ov_epsilon)
+                Sf_mag = ov_epsilon;
+
+                if (Sf_y > 0.0) {
+                  ip = SubvectorEltIndex(p_sub, i, j, k1);
+                  Press_y = pfmax((pp[ip]), 0.0);
+                  qy_v[io-sy_v] = -(Sf_y / (RPowerR(fabs(Sf_mag),0.5)*mann_dat[io])) * RPowerR(Press_y, (5.0 / 3.0));
+                }
+              }
             }
-          }
-        }
-      }
+       }
     });
 
     BCStructPatchLoop(i, j, k, fdir, ival, bc_struct, ipatch, sg,
@@ -199,99 +207,105 @@ void    OverlandFlowEvalKin(
       {
         io = SubvectorEltIndex(sx_sub, i, j, 0);
         ke_v[io] = qx_v[io];
-        kw_v[io] = qx_v[io - 1];
+        kw_v[io] = qx_v[io-1];
         kn_v[io] = qy_v[io];
-        ks_v[io] = qy_v[io - sy_v];
+        ks_v[io] = qy_v[io-sy_v];
         //printf("i=%d j=%d k=%d ke_v=%d kw_v=%d kn_v=%d ks_v=%f\n",i,j,k,ke_v[io],kw_v[io],kn_v[io],ks_v[io]);
       }
     });
+
   }
   else          //fcn = CALCDER calculates the derivs
   {
-    BCStructPatchLoopOvrlnd(i, j, k, fdir, ival, bc_struct, ipatch, sg,
-    {
-      if (fdir[2] == 1)
-      {
-        io = SubvectorEltIndex(sx_sub, i, j, 0);
-        itop = SubvectorEltIndex(top_sub, i, j, 0);
 
-        k1 = (int)top_dat[itop];
-        k0x = (int)top_dat[itop - 1];
-        k0y = (int)top_dat[itop - sy_v];
-
-        if (k1 >= 0)
+        BCStructPatchLoopOvrlnd(i, j, k, fdir, ival, bc_struct, ipatch, sg,
         {
-          ip = SubvectorEltIndex(p_sub, i, j, k1);
-          Sf_x = sx_dat[io];
-          Sf_y = sy_dat[io];
 
-          Sf_mag = RPowerR(Sf_x * Sf_x + Sf_y * Sf_y, 0.5);
-          if (Sf_mag < ov_epsilon)
-            Sf_mag = ov_epsilon;
-
-          Press_x = RPMean(-Sf_x, 0.0, pfmax((pp[ip]), 0.0), pfmax((pp[ip + 1]), 0.0));
-          Press_y = RPMean(-Sf_y, 0.0, pfmax((pp[ip]), 0.0), pfmax((pp[ip + sy_v]), 0.0));
-
-          qx_temp = -(5.0 / 3.0) * (Sf_x / (RPowerR(fabs(Sf_mag), 0.5) * mann_dat[io])) * RPowerR(Press_x, (2.0 / 3.0));
-          qy_temp = -(5.0 / 3.0) * (Sf_y / (RPowerR(fabs(Sf_mag), 0.5) * mann_dat[io])) * RPowerR(Press_y, (2.0 / 3.0));
-
-          ke_v[io] = pfmax(qx_temp, 0);
-          kw_v[io + 1] = -pfmax(-qx_temp, 0);
-          kn_v[io] = pfmax(qy_temp, 0);
-          ks_v[io + sy_v] = -pfmax(-qy_temp, 0);
-        }
-
-        //fix for lower x boundary
-        if (k0x < 0.0)
-        {
-          if (k1 >= 0.0)
+          if (fdir[2] == 1)
           {
-            Sf_x = sx_dat[io];
-            Sf_y = sy_dat[io];
 
-            double Sf_mag = RPowerR(Sf_x * Sf_x + Sf_y * Sf_y, 0.5);
-            if (Sf_mag < ov_epsilon)
-              Sf_mag = ov_epsilon;
+            io = SubvectorEltIndex(sx_sub, i, j, 0);
+            itop = SubvectorEltIndex(top_sub, i, j, 0);
 
-            if (Sf_x > 0.0)
+            k1 = (int)top_dat[itop];
+            k0x = (int)top_dat[itop - 1];
+            k0y = (int)top_dat[itop - sy_v];
+            k1x = (int)top_dat[itop + 1];
+            k1y = (int)top_dat[itop + sy_v];
+
+            if (k1 >= 0)
             {
               ip = SubvectorEltIndex(p_sub, i, j, k1);
-              Press_x = pfmax((pp[ip]), 0.0);
-              qx_temp = -(5.0 / 3.0) * (Sf_x / (RPowerR(fabs(Sf_mag), 0.5) * mann_dat[io])) * RPowerR(Press_x, (2.0 / 3.0));
+              ipp1 = (int)SubvectorEltIndex(p_sub, i+1, j, k1x);
+              ippsy = (int)SubvectorEltIndex(p_sub, i, j+sy_v, k1y);
+              Sf_x = sx_dat[io];
+              Sf_y = sy_dat[io];
 
-              kw_v[io] = qx_temp;
-              ke_v[io - 1] = qx_temp;
-            }
-          }
-        }
-
-        //fix for lower y boundary
-        if (k0y < 0.0)
-        {
-          if (k1 >= 0.0)
-          {
-            Sf_x = sx_dat[io];
-            Sf_y = sy_dat[io];
-
-            double Sf_mag = RPowerR(Sf_x * Sf_x + Sf_y * Sf_y, 0.5);  //+ov_epsilon;
-            if (Sf_mag < ov_epsilon)
+             Sf_mag = RPowerR(Sf_x*Sf_x+Sf_y*Sf_y,0.5);
+              if (Sf_mag < ov_epsilon)
               Sf_mag = ov_epsilon;
 
-            if (Sf_y > 0.0)
-            {
-              ip = SubvectorEltIndex(p_sub, i, j, k1);
-              Press_y = pfmax((pp[ip]), 0.0);
-              qy_temp = -(5.0 / 3.0) * (Sf_y / (RPowerR(fabs(Sf_mag), 0.5) * mann_dat[io])) * RPowerR(Press_y, (2.0 / 3.0));
+              Press_x = RPMean(-Sf_x, 0.0, pfmax((pp[ip]), 0.0), pfmax((pp[ipp1]), 0.0));
+              Press_y = RPMean(-Sf_y, 0.0, pfmax((pp[ip]), 0.0),pfmax((pp[ippsy]), 0.0));
 
-              ks_v[io] = qy_temp;
-              kn_v[io - sy_v] = qy_temp;
+              qx_temp = -(5.0/3.0)*(Sf_x / (RPowerR(fabs(Sf_mag),0.5)*mann_dat[io])) * RPowerR(Press_x, (2.0 / 3.0));
+              qy_temp = -(5.0/3.0)*(Sf_y / (RPowerR(fabs(Sf_mag),0.5)*mann_dat[io])) * RPowerR(Press_y, (2.0 / 3.0));
+
+              ke_v[io] = pfmax(qx_temp,0);
+              kw_v[io+1] =-pfmax(-qx_temp,0);
+              kn_v[io] = pfmax(qy_temp,0);
+              ks_v[io+sy_v] = -pfmax(-qy_temp,0);
+
             }
+
+            //fix for lower x boundary
+            if (k0x < 0.0) {
+                if (k1 >= 0.0) {
+                  Sf_x = sx_dat[io];
+                  Sf_y = sy_dat[io];
+
+                  double Sf_mag = RPowerR(Sf_x*Sf_x+Sf_y*Sf_y,0.5);
+                  if (Sf_mag < ov_epsilon)
+                  Sf_mag = ov_epsilon;
+
+                  if (Sf_x > 0.0) {
+                    ip = SubvectorEltIndex(p_sub, i, j, k1);
+                    Press_x = pfmax((pp[ip]), 0.0);
+                  qx_temp = -(5.0/3.0)*(Sf_x / (RPowerR(fabs(Sf_mag),0.5)*mann_dat[io])) * RPowerR(Press_x, (2.0 / 3.0));
+
+                    kw_v[io] = qx_temp;
+                    ke_v[io-1] = qx_temp;
+                  }
+                }
+              }
+
+              //fix for lower y boundary
+              if (k0y < 0.0) {
+                  if (k1 >= 0.0) {
+
+                    Sf_x = sx_dat[io];
+                    Sf_y = sy_dat[io];
+
+                    double Sf_mag = RPowerR(Sf_x*Sf_x+Sf_y*Sf_y,0.5); //+ov_epsilon;
+                    if (Sf_mag < ov_epsilon)
+                    Sf_mag = ov_epsilon;
+
+                    if (Sf_y > 0.0) {
+                      ip = SubvectorEltIndex(p_sub, i, j, k1);
+                      Press_y = pfmax((pp[ip]), 0.0);
+                    qy_temp = -(5.0/3.0)*(Sf_y / (RPowerR(fabs(Sf_mag),0.5)*mann_dat[io])) * RPowerR(Press_y, (2.0 / 3.0));
+
+                    ks_v[io] = qy_temp;
+                    kn_v[io-sy_v] = qy_temp;
+                    }
+                  }
+                }
           }
-        }
-      }
-    });
-  }   // else calcder
-}     // function
+        });
+
+    } // else calcder
+
+  }   // function
 
 
 //*/

--- a/pfsimulator/parflow_lib/overlandflow_eval_diffusive.c
+++ b/pfsimulator/parflow_lib/overlandflow_eval_diffusive.c
@@ -151,7 +151,7 @@ void    OverlandFlowEvalDiff(
         {
           ip = SubvectorEltIndex(p_sub, i, j, k1);
           ipp1 = (int)SubvectorEltIndex(p_sub, i+1, j, k1x);
-          ippsy = (int)SubvectorEltIndex(p_sub, i, j+sy_v, k1y);
+          ippsy = (int)SubvectorEltIndex(p_sub, i, j+1, k1y);
           Pupx = pfmax(pp[ipp1], 0.0);
           Pupy = pfmax(pp[ippsy], 0.0);
           Pupox = pfmax(opp[ipp1], 0.0);
@@ -258,7 +258,7 @@ void    OverlandFlowEvalDiff(
         {
           ip = SubvectorEltIndex(p_sub, i, j, k1);
           ipp1 = (int)SubvectorEltIndex(p_sub, i+1, j, k1x);
-          ippsy = (int)SubvectorEltIndex(p_sub, i, j+sy_v, k1y);
+          ippsy = (int)SubvectorEltIndex(p_sub, i, j+1, k1y);
           Pupx = pfmax(pp[ipp1], 0.0);
           Pupy = pfmax(pp[ippsy], 0.0);
           Pupox = pfmax(opp[ipp1], 0.0);

--- a/pfsimulator/parflow_lib/overlandflow_eval_diffusive.c
+++ b/pfsimulator/parflow_lib/overlandflow_eval_diffusive.c
@@ -103,7 +103,7 @@ void    OverlandFlowEvalDiff(
   int ival, sy_v, step;
   int            *fdir;
 
-  int i, ii, j, k, ip, ip2, ip3, ip4, ip0, io, itop;
+  int i, ii, j, k, ip, ip2, ip3, ip4, ip0, io, itop,k1x, k1y, ipp1, ippsy;
   int i1, j1, k1, k0x, k0y, iojm1, iojp1, ioip1, ioim1;
   /* @RMM get grid from global (assuming this is comp grid) to pass to CLM */
   int gnx = BackgroundNX(GlobalsBackground);
@@ -144,14 +144,18 @@ void    OverlandFlowEvalDiff(
         k1 = (int)top_dat[itop];
         k0x = (int)top_dat[itop - 1];
         k0y = (int)top_dat[itop - sy_v];
+        k1x = (int)top_dat[itop + 1];
+        k1y = (int)top_dat[itop + sy_v];
 
         if (k1 >= 0)
         {
           ip = SubvectorEltIndex(p_sub, i, j, k1);
-          Pupx = pfmax(pp[ip + 1], 0.0);
-          Pupy = pfmax(pp[ip + sy_v], 0.0);
-          Pupox = pfmax(opp[ip + 1], 0.0);
-          Pupoy = pfmax(opp[ip + sy_v], 0.0);
+          ipp1 = (int)SubvectorEltIndex(p_sub, i+1, j, k1x);
+          ippsy = (int)SubvectorEltIndex(p_sub, i, j+sy_v, k1y);
+          Pupx = pfmax(pp[ipp1], 0.0);
+          Pupy = pfmax(pp[ippsy], 0.0);
+          Pupox = pfmax(opp[ipp1], 0.0);
+          Pupoy = pfmax(opp[ippsy], 0.0);
           Pdown = pfmax(pp[ip], 0.0);
           Pdowno = pfmax(opp[ip], 0.0);
 
@@ -165,8 +169,8 @@ void    OverlandFlowEvalDiff(
           if (Sf_mag < ov_epsilon)
             Sf_mag = ov_epsilon;
 
-          Press_x = RPMean(-Sf_x, 0.0, pfmax((pp[ip]), 0.0), pfmax((pp[ip + 1]), 0.0));
-          Press_y = RPMean(-Sf_y, 0.0, pfmax((pp[ip]), 0.0), pfmax((pp[ip + sy_v]), 0.0));
+          Press_x = RPMean(-Sf_x, 0.0, pfmax((pp[ip]), 0.0), pfmax((pp[ipp1]), 0.0));
+          Press_y = RPMean(-Sf_y, 0.0, pfmax((pp[ip]), 0.0), pfmax((pp[ippsy]), 0.0));
 
           qx_v[io] = -(Sf_x / (RPowerR(fabs(Sf_mag), 0.5) * mann_dat[io])) * RPowerR(Press_x, (5.0 / 3.0));
           qy_v[io] = -(Sf_y / (RPowerR(fabs(Sf_mag), 0.5) * mann_dat[io])) * RPowerR(Press_y, (5.0 / 3.0));
@@ -247,13 +251,18 @@ void    OverlandFlowEvalDiff(
         k1 = (int)top_dat[itop];
         k0x = (int)top_dat[itop - 1];
         k0y = (int)top_dat[itop - sy_v];
+        k1x = (int)top_dat[itop + 1];
+        k1y = (int)top_dat[itop + sy_v];
+
         if (k1 >= 0)
         {
           ip = SubvectorEltIndex(p_sub, i, j, k1);
-          Pupx = pfmax(pp[ip + 1], 0.0);
-          Pupy = pfmax(pp[ip + sy_v], 0.0);
-          Pupox = pfmax(opp[ip + 1], 0.0);
-          Pupoy = pfmax(opp[ip + sy_v], 0.0);
+          ipp1 = (int)SubvectorEltIndex(p_sub, i+1, j, k1x);
+          ippsy = (int)SubvectorEltIndex(p_sub, i, j+sy_v, k1y);
+          Pupx = pfmax(pp[ipp1], 0.0);
+          Pupy = pfmax(pp[ippsy], 0.0);
+          Pupox = pfmax(opp[ipp1], 0.0);
+          Pupoy = pfmax(opp[ippsy], 0.0);
           Pdown = pfmax(pp[ip], 0.0);
           Pdowno = pfmax(opp[ip], 0.0);
 


### PR DESCRIPTION
Fixed a bug in overland kinematic and overland diffusive that used the top function / macro incorrectly causing problems in 3D, orthogonal grid domains with a ground surface that is variable in z.