### PR TITLE
AMPS tests where not linking to MPI libraries

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -111,7 +111,7 @@ RUN git clone -b master --single-branch https://github.com/parflow/parflow.git p
 
 RUN mkdir -p build && \
     cd build && \
-    CC=mpicc CXX=mpic++ LDFLAGS="-lcurl" cmake ../parflow \
+    LDFLAGS="-lcurl" cmake ../parflow \
        -DPARFLOW_AMPS_LAYER=mpi1 \
        -DPARFLOW_AMPS_SEQUENTIAL_IO=TRUE \
        -DHYPRE_ROOT=$PARFLOW_DIR \

--- a/pfsimulator/amps/test/src/CMakeLists.txt
+++ b/pfsimulator/amps/test/src/CMakeLists.txt
@@ -37,6 +37,12 @@ list(REMOVE_DUPLICATES ALL_TESTS)
 foreach(test ${ALL_TESTS})
   add_executable( ${test} ${test}.c)
   target_link_libraries(${test} amps)
+  
+  if (${PARFLOW_HAVE_MPI})
+    # In CMake 3.13 this could be target_link_options
+    target_link_libraries(${test} ${MPI_LINK_FLAGS})
+    target_link_libraries (${test} ${MPI_LIBRARIES})
+  endif (${PARFLOW_HAVE_MPI})
 endforeach()
 
 foreach(test ${SEQUENTIAL_TESTS})


### PR DESCRIPTION
When the AMPS tests were introduced the CMake build rules didn't include MPI libraries which caused link failures in build.

Fixes #225 