### PR TITLE
README fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ using MPI libraries.  CLM is being enabled.
    mkdir build
    cd build
    cmake ../parflow \
-   	 -DCMAKE_INSTALL_PREFIX=$(PARFLOW_DIR) \
+   	 -DCMAKE_INSTALL_PREFIX=${PARFLOW_DIR} \
    	 -DPARFLOW_HAVE_CLM=ON
 ```
 
@@ -178,7 +178,7 @@ is a minimal example of an MPI build with CLM:
    mkdir build
    cd build
    cmake ../parflow \
-      	 -DCMAKE_INSTALL_PREFIX=$(PARFLOW_DIR) \
+      	 -DCMAKE_INSTALL_PREFIX=${PARFLOW_DIR} \
    	 -DPARFLOW_HAVE_CLM=ON \
 	 -DPARFLOW_AMPS_LAYER=mpi1
 ```
@@ -191,14 +191,13 @@ packages are being specified and some features are being enabled:
    cd build
    cmake ../parflow \
         -DPARFLOW_AMPS_LAYER=mpi1 \
-	-DHYPRE_ROOT=$(PARFLOW_HYPRE_DIR) \
-	-DHDF5_ROOT=$(PARFLOW_HDF5_DIR) \
-	-DSILO_ROOT=$(PARFLOW_SILO_DIR) \
-	-DSUNDIALS_ROOT=$(PARFLOW_SUNDIALS_DIR) \
+	-DHYPRE_ROOT=${PARFLOW_HYPRE_DIR} \
+	-DHDF5_ROOT=${PARFLOW_HDF5_DIR} \
+	-DSILO_ROOT=${PARFLOW_SILO_DIR} \
 	-DCMAKE_BUILD_TYPE=Debug \
 	-DPARFLOW_ENABLE_TIMING=TRUE \
 	-DPARFLOW_HAVE_CLM=ON \
-	-DCMAKE_INSTALL_PREFIX=$(INSTALL_DIR)
+	-DCMAKE_INSTALL_PREFIX=${INSTALL_DIR}
 ```
 
 ### Step 4: Building and installing
@@ -246,11 +245,11 @@ building of the documentation.
    cmake ../parflow \
         <other cmake options> \
 	-DPARFLOW_ENABLE_LATEX=TRUE \
-	-DCMAKE_INSTALL_PREFIX=$(INSTALL_DIR)
+	-DCMAKE_INSTALL_PREFIX=${INSTALL_DIR}
 ```
 
 When make is run the documenation will be built and installed in
-$(INSTALL_DIR)/docs/user_manual.pdf.
+${INSTALL_DIR}/docs/user_manual.pdf.
 
 ### Code documentation
 


### PR DESCRIPTION
Remove sundials mention in readme since it is rarely used, causes confusion.
Fixed shell syntax to be ${} rather than $()

Fixes #242 