### PR TITLE
make amps_sequential_io default TRUE

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -138,12 +138,12 @@ if((NOT PARFLOW_HAVE_CUDA) AND (${PARFLOW_AMPS_LAYER} STREQUAL "cuda"))
   message(FATAL_ERROR "ERROR: Using PARFLOW_AMPS_LAYER=cuda requires building with GPU acceleration!")
 endif((NOT PARFLOW_HAVE_CUDA) AND (${PARFLOW_AMPS_LAYER} STREQUAL "cuda"))
 
-option(PARFLOW_AMPS_SEQUENTIAL_IO "Use AMPS single file I/O model for output of PFB files" "FALSE")
+option(PARFLOW_AMPS_SEQUENTIAL_IO "Use AMPS single file I/O model for output of PFB files" "TRUE")
 
 if (${PARFLOW_AMPS_SEQUENTIAL_IO})
   message("Using single file AMPS I/O for PFB output")
 else ()
-  message("Using multiple file AMPS I/O for PFB output")
+  message("Using multiple file AMPS I/O for PFB output (deprecated)")
   set(AMPS_SPLIT_FILE "yes")
 endif ()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -143,7 +143,7 @@ option(PARFLOW_AMPS_SEQUENTIAL_IO "Use AMPS single file I/O model for output of 
 if (${PARFLOW_AMPS_SEQUENTIAL_IO})
   message("Using single file AMPS I/O for PFB output")
 else ()
-  message("Using multiple file AMPS I/O for PFB output (deprecated)")
+  message("Using multiple file AMPS I/O for PFB output")
   set(AMPS_SPLIT_FILE "yes")
 endif ()
 


### PR DESCRIPTION
Would like to change the default build from using distributed IO to using sequential IO. In talking with @reedmaxwell, it was suggested that we make this change so new installations won't require explicitly setting the DPARFLOW_AMPS_SEQUENTIAL_IO=TRUE in every compilation.