### PR TITLE
Bugfix Valgrind warnings

### DIFF
--- a/bin/valgrind.sup
+++ b/bin/valgrind.sup
@@ -293,7 +293,7 @@
 #
 ###############################################################
 {
-   <insert_a_suppression_name_here>
+   CLM-Write
    Memcheck:Cond
    fun:write_decimal.constprop.10
    fun:write_integer

--- a/bin/valgrind.sup
+++ b/bin/valgrind.sup
@@ -279,6 +279,22 @@
    ...
 }
 
+###############################################################
+#
+# GNU Fortran
+#
+###############################################################
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Cond
+   fun:write_decimal.constprop.10
+   fun:write_integer
+   fun:list_formatted_write_scalar
+   fun:_gfortrani_list_formatted_write
+   ...
+}
+
+
 ##############################################################################
 #
 # CLM allocates but does not free
@@ -296,3 +312,5 @@
    fun:Solve
    fun:main
 }
+
+

--- a/bin/valgrind.sup
+++ b/bin/valgrind.sup
@@ -293,7 +293,7 @@
 #
 ###############################################################
 {
-   CLM-Write
+   <insert_a_suppression_name_here>
    Memcheck:Cond
    fun:write_decimal.constprop.10
    fun:write_integer

--- a/bin/valgrind.sup
+++ b/bin/valgrind.sup
@@ -221,6 +221,14 @@
 
 {
    <insert_a_suppression_name_here>
+   Memcheck:Param
+   rt_sigaction(act->sa_mask)
+   ...
+   fun:PMPI_Init
+}
+
+{
+   <insert_a_suppression_name_here>
    Memcheck:Cond
    ...
    fun:mv2_get_arch_hca_type

--- a/pfsimulator/clm/drv_readvegpf.F90
+++ b/pfsimulator/clm/drv_readvegpf.F90
@@ -53,6 +53,12 @@ subroutine drv_readvegpf (drv,grid,tile,clm)
   ! Open and read 1-D  CLM input file
   open(9, file=drv%vegpf, form='formatted', status = 'old',action='read')
 
+
+  ! Setup defaults; this prevents use of unitialized state
+  do t=1,drv%nch 
+     clm(t)%irrig = 0  !default - no irrigation
+  end do
+
   ioval=0
   do while (ioval == 0)
 


### PR DESCRIPTION
GNU Fortran is generating a valgrind error in the write command.   This is known issue; added a valgrind suppression entry to silence.
MPI was generating a valgrind error in MPI_Init on quarts;  suppression was added to silence.

