### PR TITLE
Bugfix/problem real space z no domain on rank

### DIFF
--- a/pfsimulator/parflow_lib/problem_real_space_z.c
+++ b/pfsimulator/parflow_lib/problem_real_space_z.c
@@ -132,6 +132,7 @@ void realSpaceZ(ProblemData *problem_data, Vector *rsz)
         ips = SubvectorEltIndex(rsz_sub, i, j, k);
 
         breaking_out_PV_visiting = PV_visiting;
+	// Can't just do a break since GrGeom loops are multiple levels deep.
         goto  breakout;
       });
 
@@ -142,12 +143,15 @@ breakout:;
        * domain on this rank.   If not then nothing 
        * was in domain.
        */
+
+      // Free temporary space allocated in GrGeomInLoop if needed since we did a goto.
       if (breaking_out_PV_visiting)
       {
         tfree(breaking_out_PV_visiting - 1);
       }
 
-      if (k < nz)
+      // GrGeomInLoop didnt' find any points in domain
+      if (k - iz < nz)
       {
         z += 0.5 * RealSpaceDZ(SubgridRZ(subgrid)) * dz_data[ips];
         zz[k - iz] = z;

--- a/pfsimulator/parflow_lib/problem_real_space_z.c
+++ b/pfsimulator/parflow_lib/problem_real_space_z.c
@@ -128,7 +128,7 @@ void realSpaceZ(ProblemData *problem_data, Vector *rsz)
       int *breaking_out_PV_visiting = 0;
       GrGeomInLoop(i, j, k, gr_domain, r, ix, iy, l, nx, ny, 1,
       {
-        //we need one index of level k which is inside the domain
+        //we need one index of level l which is inside the domain
         ips = SubvectorEltIndex(rsz_sub, i, j, k);
 
         breaking_out_PV_visiting = PV_visiting;
@@ -136,13 +136,23 @@ void realSpaceZ(ProblemData *problem_data, Vector *rsz)
       });
 
 breakout:;
+
+      /* 
+       * If we broke out of GrGeomInLoop we found point in 
+       * domain on this rank.   If not then nothing 
+       * was in domain.
+       */
       if (breaking_out_PV_visiting)
       {
         tfree(breaking_out_PV_visiting - 1);
       }
-      z += 0.5 * RealSpaceDZ(SubgridRZ(subgrid)) * dz_data[ips];
-      zz[k - iz] = z;
-      z += 0.5 * RealSpaceDZ(SubgridRZ(subgrid)) * dz_data[ips];
+
+      if (k < nz)
+      {
+        z += 0.5 * RealSpaceDZ(SubgridRZ(subgrid)) * dz_data[ips];
+        zz[k - iz] = z;
+        z += 0.5 * RealSpaceDZ(SubgridRZ(subgrid)) * dz_data[ips];
+      }
     }
 
     /* Send partial sum to rank above current rank */


### PR DESCRIPTION
The computation of the real space z vector was running beyond temporary array (zz) resulting in memory errors.
This patch prevents the overwrite.   There may still be issues with processing on ranks with no cells contained within the domain when number of processors in Z (Q) is greater than 1.