### PR TITLE
Cleaned up declaration and initialization of AMPS_CPU_TICKS_PER_SEC.

### DIFF
--- a/pfsimulator/amps/cuda/amps_init.c
+++ b/pfsimulator/amps/cuda/amps_init.c
@@ -42,10 +42,6 @@ int amps_mpi_initialized = FALSE;
 char amps_malloclog[MAXPATHLEN];
 #endif
 
-#ifndef AMPS_CPU_TICKS_PER_SEC
-long AMPS_CPU_TICKS_PER_SEC;
-#endif
-
 int amps_size;
 int amps_rank;
 int amps_node_rank;
@@ -243,19 +239,11 @@ int amps_EmbeddedInit(void)
   setbuf(stdout, NULL);
 #endif
 
-#ifdef CASC_HAVE_GETTIMEOFDAY
   amps_clock_init();
-#endif
 
 #ifdef AMPS_MALLOC_DEBUG
   dmalloc_logpath = amps_malloclog;
   sprintf(dmalloc_logpath, "malloc.log.%04d", amps_Rank(amps_CommWorld));
-#endif
-
-#ifdef TIMING
-#ifndef CRAY_TIME
-  AMPS_CPU_TICKS_PER_SEC = sysconf(_SC_CLK_TCK);
-#endif
 #endif
 
   return 0;

--- a/pfsimulator/amps/mpi1/amps_init.c
+++ b/pfsimulator/amps/mpi1/amps_init.c
@@ -42,10 +42,6 @@ int amps_mpi_initialized = FALSE;
 char amps_malloclog[MAXPATHLEN];
 #endif
 
-#ifndef AMPS_CPU_TICKS_PER_SEC
-long AMPS_CPU_TICKS_PER_SEC;
-#endif
-
 int amps_size;
 int amps_rank;
 int amps_node_rank;
@@ -239,19 +235,11 @@ int amps_EmbeddedInit(void)
   setbuf(stdout, NULL);
 #endif
 
-#ifdef CASC_HAVE_GETTIMEOFDAY
   amps_clock_init();
-#endif
 
 #ifdef AMPS_MALLOC_DEBUG
   dmalloc_logpath = amps_malloclog;
   sprintf(dmalloc_logpath, "malloc.log.%04d", amps_Rank(amps_CommWorld));
-#endif
-
-#ifdef TIMING
-#ifndef CRAY_TIME
-  AMPS_CPU_TICKS_PER_SEC = sysconf(_SC_CLK_TCK);
-#endif
 #endif
 
   return 0;

--- a/pfsimulator/amps/oas3/amps_init.c
+++ b/pfsimulator/amps/oas3/amps_init.c
@@ -44,10 +44,6 @@ int amps_mpi_initialized = FALSE;
 char amps_malloclog[MAXPATHLEN];
 #endif
 
-#ifndef CRAY_TIME
-long AMPS_CPU_TICKS_PER_SEC;
-#endif
-
 int amps_size;
 int amps_rank;
 
@@ -112,9 +108,7 @@ int amps_Init(int *argc, char **argv[])
   setbuf(stdout, NULL);
 #endif
 
-#ifdef CASC_HAVE_GETTIMEOFDAY
   amps_clock_init();
-#endif
 
 #ifdef AMPS_MPI_SETHOME
   if (!amps_rank)
@@ -149,12 +143,6 @@ int amps_Init(int *argc, char **argv[])
 #ifdef AMPS_MALLOC_DEBUG
   dmalloc_logpath = amps_malloclog;
   sprintf(dmalloc_logpath, "malloc.log.%04d", amps_Rank(amps_CommWorld));
-#endif
-
-#ifdef TIMING
-#ifndef CRAY_TIME
-  AMPS_CPU_TICKS_PER_SEC = sysconf(_SC_CLK_TCK);
-#endif
 #endif
 
 #ifdef AMPS_PRINT_HOSTNAME
@@ -199,19 +187,11 @@ int amps_EmbeddedInit(void)
   setbuf(stdout, NULL);
 #endif
 
-#ifdef CASC_HAVE_GETTIMEOFDAY
   amps_clock_init();
-#endif
 
 #ifdef AMPS_MALLOC_DEBUG
   dmalloc_logpath = amps_malloclog;
   sprintf(dmalloc_logpath, "malloc.log.%04d", amps_Rank(amps_CommWorld));
-#endif
-
-#ifdef TIMING
-#ifndef CRAY_TIME
-  AMPS_CPU_TICKS_PER_SEC = sysconf(_SC_CLK_TCK);
-#endif
 #endif
 
   return 0;

--- a/pfsimulator/amps/smpi/amps_init.c
+++ b/pfsimulator/amps/smpi/amps_init.c
@@ -42,10 +42,6 @@ int amps_mpi_initialized = FALSE;
 char amps_malloclog[MAXPATHLEN];
 #endif
 
-#ifndef AMPS_CPU_TICKS_PER_SEC
-long AMPS_CPU_TICKS_PER_SEC;
-#endif
-
 int amps_size;
 int amps_rank;
 int amps_node_rank;
@@ -240,19 +236,11 @@ int amps_EmbeddedInit(void)
   setbuf(stdout, NULL);
 #endif
 
-#ifdef CASC_HAVE_GETTIMEOFDAY
   amps_clock_init();
-#endif
 
 #ifdef AMPS_MALLOC_DEBUG
   dmalloc_logpath = amps_malloclog;
   sprintf(dmalloc_logpath, "malloc.log.%04d", amps_Rank(amps_CommWorld));
-#endif
-
-#ifdef TIMING
-#ifndef CRAY_TIME
-  AMPS_CPU_TICKS_PER_SEC = sysconf(_SC_CLK_TCK);
-#endif
 #endif
 
   return 0;


### PR DESCRIPTION
Cleaned up declaration and initialization of AMPS_CPU_TICKS_PER_SEC.   Old initialization logic from deprecated platforms was declaring and initializing AMPS_CPU_TICKS_PER_SEC twice.