### PR TITLE
Fix a few issues with pftools python CLM

### DIFF
--- a/pftools/python/parflow/tools/io.py
+++ b/pftools/python/parflow/tools/io.py
@@ -300,6 +300,12 @@ def to_native_type(string):
             return t(string)
         except ValueError:
             pass
+
+    # Handle boolean type
+    lower_str = string.lower()
+    if lower_str in ['true', 'false']:
+        return lower_str[0] == 't'
+
     return string
 
 

--- a/pftools/python/setup.py
+++ b/pftools/python/setup.py
@@ -7,7 +7,7 @@ README = (HERE / "README.md").read_text()
 
 setup(
     name='pftools',
-    version="1.1.0",
+    version="1.1.1",
     description=('A Python package creating an interface with the ParFlow '
                  'hydrologic model.'),
     long_description=README,


### PR DESCRIPTION
1. The map and parameter file names are now pulled from the "drv_clmin.dat" file
   before attempting to load them. Previously, they were assumed to be
   "drv_vegm.dat" and "drv_vegp.dat".

2. When checking if the driver data is set, it now checks if land covers have
   been set. Previously, it checked if the type of "Sand" was set, but that
   is now always set since it defaults to "Constant".

3. Boolean type is now checked in the to_native_type() function.

This also bumps the version to 1.1.1.