### PR TITLE
Update silo url

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -202,7 +202,7 @@ jobs:
         CACHE_HIT: ${{steps.cache-parflow-dependencies.outputs.cache-hit}}
       run: |
         if [[ "$CACHE_HIT" != 'true' ]]; then
-          # wget -nv https://wci.llnl.gov/content/assets/docs/simulation/computer-codes/silo/silo-4.10.2/silo-4.10.2.tar.gz
+          # wget -nv https://wci.llnl.gov/sites/wci/files/2021-01/silo-4.10.2.tgz
           # Use mirror for reliablity
           wget -nv https://raw.githubusercontent.com/parflow/parflow-dependencies/master/silo-4.10.2.tar.gz
           tar -xf silo-4.10.2.tar.gz

--- a/Dockerfile
+++ b/Dockerfile
@@ -77,7 +77,7 @@ run wget -q https://github.com/Unidata/netcdf-c/archive/v4.5.0.tar.gz && \
 WORKDIR /home/parflow
 RUN wget -nv --no-check-certificate http://cmake.org/files/v3.14/cmake-3.14.5-Linux-x86_64.tar.gz && \
     tar -xvf cmake-3.14.5-Linux-x86_64.tar.gz && \
-    curl "https://wci.llnl.gov/content/assets/docs/simulation/computer-codes/silo/silo-4.10.2/silo-4.10.2.tar.gz" -o "silo-4.10.2.tar.gz" && \
+    curl "https://wci.llnl.gov/sites/wci/files/2021-01/silo-4.10.2.tgz" -o "silo-4.10.2.tar.gz" && \
     tar -xf silo-4.10.2.tar.gz && \
     cd silo-4.10.2 && \
     ./configure  --prefix=$PARFLOW_DIR --disable-silex --disable-hzip --disable-fpzip && \

--- a/Dockerfile_CUDA
+++ b/Dockerfile_CUDA
@@ -81,7 +81,7 @@ RUN wget https://download.open-mpi.org/release/open-mpi/v4.0/openmpi-4.0.3.tar.g
 # SILO
 #
 WORKDIR /home/parflow
-RUN curl "https://wci.llnl.gov/content/assets/docs/simulation/computer-codes/silo/silo-4.10.2/silo-4.10.2.tar.gz" -o "silo-4.10.2.tar.gz" && \
+RUN curl "https://wci.llnl.gov/sites/wci/files/2021-01/silo-4.10.2.tgz" -o "silo-4.10.2.tar.gz" && \
     tar -xf silo-4.10.2.tar.gz && \
     cd silo-4.10.2 && \
     ./configure  --prefix=$PARFLOW_DIR --disable-silex --disable-hzip --disable-fpzip && \

--- a/cmake/recipes/centos-7-3
+++ b/cmake/recipes/centos-7-3
@@ -25,7 +25,7 @@ sudo yum install -y hdf5-openmpi hdf5-openmpi-devel
 sudo yum install -y zlib zlib-devel
 
 # Build SILO
-wget https://wci.llnl.gov/content/assets/docs/simulation/computer-codes/silo/silo-4.10.2/silo-4.10.2.tar.gz
+wget https://wci.llnl.gov/sites/wci/files/2021-01/silo-4.10.2.tgz
 tar xf silo-4.10.2.tar.gz
 cd silo-4.10.2
 #CC=mpicc CXX=mpicxx ./configure --prefix=/usr/local --with-hdf5=/usr/include/openmpi-x86_64/,/usr/lib64/openmpi/lib

--- a/cmake/recipes/centos-7.3
+++ b/cmake/recipes/centos-7.3
@@ -18,7 +18,7 @@ sudo yum -y install zlib-devel
 
 wget --no-check-certificate http://cmake.org/files/v3.4/cmake-3.4.3-Linux-x86_64.tar.gz && tar -xvf cmake-3.4.3-Linux-x86_64.tar.gz
 
-wget https://wci.llnl.gov/content/assets/docs/simulation/computer-codes/silo/silo-4.10.2/silo-4.10.2-bsd.tar.gz
+wget https://wci.llnl.gov/sites/wci/files/2021-01/silo-4.10.2-bsd.tgz
 tar xf silo-4.10.2-bsd.tar.gz
 cd silo-4.10.2-bsd
 ./configure --prefix=/usr/local

--- a/cmake/recipes/ncar-cheyenne
+++ b/cmake/recipes/ncar-cheyenne
@@ -60,7 +60,7 @@ then
 
     pushd silo
 
-    wget https://wci.llnl.gov/content/assets/docs/simulation/computer-codes/silo/silo-4.10.2/silo-4.10.2.tar.gz
+    wget https://wci.llnl.gov/sites/wci/files/2021-01/silo-4.10.2.tgz
     tar xf silo-4.10.2.tar.gz
 
     pushd silo-4.10.2

--- a/cmake/recipes/nersc-cori
+++ b/cmake/recipes/nersc-cori
@@ -110,7 +110,7 @@ then
    echo "Building in Silo"
    echo "*****************************************************************************"
    
-   wget https://wci.llnl.gov/content/assets/docs/simulation/computer-codes/silo/silo-4.10.2/silo-4.10.2.tar.gz
+   wget https://wci.llnl.gov/sites/wci/files/2021-01/silo-4.10.2.tgz
    tar xf silo-4.10.2.tar.gz
    pushd silo-4.10.2
    CC=${PARFLOW_CC} CXX=${PARFLOW_CXX} ./configure --prefix=$PARFLOW_DIR \

--- a/cmake/recipes/ubuntu-18.10-CUDA
+++ b/cmake/recipes/ubuntu-18.10-CUDA
@@ -70,7 +70,7 @@ cd ../..
 sudo rm -fr hypre-2.17.0 v2.17.0.tar.gz
 
 #Install Silo
-wget https://wci.llnl.gov/content/assets/docs/simulation/computer-codes/silo/silo-4.10.2/silo-4.10.2.tar.gz && tar -xvf silo-4.10.2.tar.gz
+wget https://wci.llnl.gov/sites/wci/files/2021-01/silo-4.10.2.tgz && tar -xvf silo-4.10.2.tar.gz
 cd silo-4.10.2
 ./configure --prefix=$PFDIR/silo --disable-silex --disable-hzip --disable-fpzip && make install
 cd ..

--- a/docker/CMakeLists.txt
+++ b/docker/CMakeLists.txt
@@ -4,7 +4,7 @@ add_custom_target(DockerBuildDevelopment
     # --build-arg "CMAKE_URL=https://cmake.org/files/v3.18/cmake-3.18.2-Linux-x86_64.tar.gz"
     # --build-arg "HDF5_URL=https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-1.12/hdf5-1.12.0/src/hdf5-1.12.0.tar.gz"
     # --build-arg "NETCDF_URL=https://github.com/Unidata/netcdf-c/archive/v4.7.4.tar.gz"
-    # --build-arg "SILO_URL=https://wci.llnl.gov/content/assets/docs/simulation/computer-codes/silo/silo-4.10.2/silo-4.10.2.tar.gz"
+    # --build-arg "SILO_URL=https://wci.llnl.gov/sites/wci/files/2021-01/silo-4.10.2.tgz"
     # --build-arg "HYPRE_VERSION=v2.19.0"
     -f "${CMAKE_CURRENT_SOURCE_DIR}/dev/Dockerfile"
     "${CMAKE_CURRENT_SOURCE_DIR}/.."

--- a/docker/dev/Dockerfile
+++ b/docker/dev/Dockerfile
@@ -17,7 +17,7 @@
 #    *  https://github.com/Unidata/netcdf-c/archive/v4.7.4.tar.gz
 #
 #  SILO_URL
-#    *  https://wci.llnl.gov/content/assets/docs/simulation/computer-codes/silo/silo-4.10.2/silo-4.10.2.tar.gz
+#    *  https://wci.llnl.gov/sites/wci/files/2021-01/silo-4.10.2.tgz
 #
 #  HYPRE_VERSION
 #    *  v2.19.0
@@ -123,7 +123,7 @@ USER ubuntu
 # Install SILO
 # -----------------------------------------------------------------------------
 
-ARG SILO_URL=https://wci.llnl.gov/content/assets/docs/simulation/computer-codes/silo/silo-4.10.2/silo-4.10.2.tar.gz
+ARG SILO_URL=https://wci.llnl.gov/sites/wci/files/2021-01/silo-4.10.2.tgz
 
 ENV SILO_DIR /opt/silo
 


### PR DESCRIPTION
I didn't find any official documentation that the url changed. But you will
notice that these urls no longer work:

https://wci.llnl.gov/content/assets/docs/simulation/computer-codes/silo/silo-4.10.2/silo-4.10.2.tar.gz
https://wci.llnl.gov/content/assets/docs/simulation/computer-codes/silo/silo-4.10.2/silo-4.10.2-bsd.tar.gz

And if you go to their [downloads page](https://wci.llnl.gov/simulation/computer-codes/silo), you will
see that the download links now point to these urls:

https://wci.llnl.gov/sites/wci/files/2021-01/silo-4.10.2.tgz
https://wci.llnl.gov/sites/wci/files/2021-01/silo-4.10.2-bsd.tgz