### PR TITLE
Updated links for ParFlow users email list to point to the new Google Group list

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,8 +28,7 @@ and feel free to propose changes to this document in a pull request.
 faster results by using the resources below.  Issues are meant for bug
 reports and feature requests.
 
-The [ParFlow email
-list](https://mailman.mines.edu/mailman/listinfo/parflow-users) is
+The [Parflow-Users](https://groups.google.com/g/parflow) is
 seen by many ParFlow users and developers.  You can also subscribe to
 the email list.  The traffic is minimal and is the platform for
 discussing ParFlow questions.

--- a/README.md
+++ b/README.md
@@ -44,9 +44,10 @@ two additional papers that describe the coupled model physics:
 The ParFlow website has additional information on the project:
 - [Parflow Web Site](https://parflow.org/)
 
-You can join the Parflow mailing list to communicate with the Parflow
-developers and users.  Join our mailing list over via:
-- [Parflow-Users](https://mailman.mines.edu/mailman/listinfo/parflow-users)
+You can join the Parflow Google Group/mailing list to communicate with
+the Parflow developers and users.  In order to post you will have to
+join the group, old posts are visible without joining:
+- [Parflow-Users](https://groups.google.com/g/parflow)
 
 A Parflow blog is available with notes from users on how to compile and use Parflow:
 - [Parflow Blog](http://parflow.blogspot.com/)

--- a/docs/software_plan.md
+++ b/docs/software_plan.md
@@ -468,15 +468,12 @@ questions from the listserve (below) and the user community to provide
 extended answers, how-to type tutorials and additional code information 
 (including discussion of recent papers, etc).  There is also a ParFlow 
 website under development that will be located at: <http://www.parflow.org>.
-The website will be hosted by the Juelich Research Centre.  
+The website will be hosted by the Juelich Research Centre.
 
-Lastly, the team maintains a user email list where questions or concerns can 
-be posted.  The list is available here: 
-<https://mailman.mines.edu/mailman/listinfo/parflow-users>.  The list is archived 
-here: <https://mailman.mines.edu/pipermail/parflow-users/>.  The listserve 
-is available to all users and provides a community 
-resource for answering common ParFlow questions.  
-
+Lastly, the team maintains a user email list where questions or
+concerns can be posted.  The list is available here:
+[Parflow-Users](https://groups.google.com/g/parflow).  The list is
+archived on the Google Groups site for searching pevious questions.
 
 ## 7. ParFlow Developer Training
 

--- a/pftools/python/README.md
+++ b/pftools/python/README.md
@@ -111,6 +111,6 @@ contained within the main ParFlow repo (see https://github.com/parflow/parflow)
 If you have any issues or questions about the code, please refer to one of the
 following options:
 
-   - User mailing list: https://mailman.mines.edu/mailman/listinfo/parflow-users
-   - ParFlow blog: http://parflow.blogspot.com
-   - GitHub repo (for tracking issues and requesting features): https://github.com/parflow/parflow
+   - User mailing list: [Parflow-Users](https://groups.google.com/g/parflow)
+   - ParFlow blog: [Parflow Blog](http://parflow.blogspot.com/)
+   - GitHub repo (for tracking issues and requesting features): [Parflow Issue Tracker](https://github.com/parflow/parflow/issues)


### PR DESCRIPTION
Fixed links from old mines mailman link to use new Google Groups list.

Fixes  #306