### PR TITLE
Py pftools misc fix

### DIFF
--- a/pftools/python/parflow/tools/core.py
+++ b/pftools/python/parflow/tools/core.py
@@ -277,8 +277,7 @@ class Run(BaseRun):
 
         # Try to solve order sensitive property settings
         while '_pfstore_' in new_run.__dict__:
-            invalid_props = new_run.__dict__['_pfstore_']
-            del new_run.__dict__['_pfstore_']
+            invalid_props = new_run.__dict__.pop('_pfstore_')
             previous_size = len(invalid_props)
             for key, value in invalid_props.items():
                 new_run.pfset(key, value, silence_if_undefined=True)
@@ -290,8 +289,7 @@ class Run(BaseRun):
 
         # Print any remaining key with no mapping
         if '_pfstore_' in new_run.__dict__:
-            invalid_props = new_run.__dict__['_pfstore_']
-            del new_run.__dict__['_pfstore_']
+            invalid_props = new_run.__dict__.pop('_pfstore_')
             for key, value in invalid_props.items():
                 new_run.pfset(key, value)
 

--- a/pftools/python/parflow/tools/core.py
+++ b/pftools/python/parflow/tools/core.py
@@ -277,7 +277,10 @@ class Run(BaseRun):
 
         if ext == 'pfidb':
             # Import CLM files if we need to
-            CLMImporter(new_run).import_if_needed()
+            try:
+                CLMImporter(new_run).import_if_needed()
+            except:
+                print(' => Error during CLM import - CLM specific key have been skipped')
 
         return new_run
 

--- a/pftools/python/parflow/tools/database/core.py
+++ b/pftools/python/parflow/tools/database/core.py
@@ -717,7 +717,7 @@ class PFDBObj:
             while root._parent_ is not None:
                 root = root._parent_
 
-            if container is not None:
+            if container is not None and key is not None:
                 full_key_name = '.'.join([container.full_name(), key])
                 if '_pfstore_' in root.__dict__:
                     store = root.__dict__['_pfstore_']
@@ -727,15 +727,15 @@ class PFDBObj:
             # no container were found need to start from root
             path_tokens = location.split('/')
 
-            if not path_tokens[0]:
+            if len(path_tokens[0]) == 0:
                 # We have abs_path
                 full_key_name = '.'.join(path_tokens[1:])
-            else:
+            elif len(path_tokens):
                 # relative path
                 local_root = self
-                while path_tokens[0] == '.':
+                while len(path_tokens) and path_tokens[0] == '.':
                     path_tokens.pop(0)
-                while path_tokens[0] == '..':
+                while len(path_tokens) and path_tokens[0] == '..':
                     local_root = local_root._parent_
                     path_tokens.pop(0)
 

--- a/pftools/python/parflow/tools/database/core.py
+++ b/pftools/python/parflow/tools/database/core.py
@@ -722,7 +722,6 @@ class PFDBObj:
                 if '_pfstore_' in root.__dict__:
                     store = root.__dict__['_pfstore_']
                     if full_key_name in store:
-                        print('fast store path')
                         return store[full_key_name], root, full_key_name
 
             # no container were found need to start from root

--- a/pftools/python/requirements.txt
+++ b/pftools/python/requirements.txt
@@ -1,1 +1,1 @@
-PyYAML==5.3.1
+PyYAML==5.4

--- a/pftools/python/setup.py
+++ b/pftools/python/setup.py
@@ -21,7 +21,7 @@ setup(
     ],
     keywords=['ParFlow', 'groundwater model', 'surface water model'],
     packages=find_packages(),
-    install_requires=['pyyaml==5.3.1', 'numpy'],
+    install_requires=['pyyaml==5.4', 'numpy'],
     include_package_data=True,
     extras_require={
         'all': [

--- a/pftools/python/setup.py
+++ b/pftools/python/setup.py
@@ -7,7 +7,7 @@ README = (HERE / "README.md").read_text()
 
 setup(
     name='pftools',
-    version="1.1.2",
+    version="1.1.3",
     description=('A Python package creating an interface with the ParFlow '
                  'hydrologic model.'),
     long_description=README,


### PR DESCRIPTION
Fix the following set of issues:
- Allow .value() to properly resolve keys in store
- Allow pfset to auto detect key prefix and store value in the proper container
- Add flexibility in property order when loading `from_definition`
- If CLM .dat file are not found, skip the generation of CLM keys