### PR TITLE
support for changing dx/dy/dz while writing pfb file

### DIFF
--- a/pftools/python/parflow/tools/io.py
+++ b/pftools/python/parflow/tools/io.py
@@ -35,7 +35,7 @@ def read_array(file_name):
 
 # -----------------------------------------------------------------------------
 
-def write_array(file_name, array):
+def write_array(file_name, array, *args, **kwargs):
     ext = Path(file_name).suffix[1:]
     funcs = {
         'pfb': write_array_pfb,
@@ -44,7 +44,7 @@ def write_array(file_name, array):
     if ext not in funcs:
         raise Exception(f'Unknown extension: {file_name}')
 
-    return funcs[ext](file_name, array)
+    return funcs[ext](file_name, array, *args, **kwargs)
 
 
 # -----------------------------------------------------------------------------
@@ -59,7 +59,7 @@ def read_array_pfb(file_name):
 
 # -----------------------------------------------------------------------------
 
-def write_array_pfb(file_name, array):
+def write_array_pfb(file_name, array, dx=1, dy=1, dz=1):
     # Ensure this is 3 dimensions, since parflowio requires 3 dimensions.
     while array.ndim < 3:
         array = array[np.newaxis, :]
@@ -70,6 +70,9 @@ def write_array_pfb(file_name, array):
     from parflowio.pyParflowio import PFData
     data = PFData()
     data.setDataArray(array)
+    data.setDX(dx)
+    data.setDY(dy)
+    data.setDZ(dz)
     return data.writeFile(file_name)
 
 


### PR DESCRIPTION
`parflowio` has support for specifying DX/DY/DZ values of the `PFData` object, in addition to the array values themselves. I'm not sure what's special about DX/DY/DZ among all possible attributes of the run - none of the code in `parflowio` seems to be doing anything useful with this information other than keeping track of it, as far as I can tell. Nevertheless, support for these fields exist in the pfb file, so `parflowio` exposes getters/setters for these fields.

@reedmaxwell observed that the values reported by `parflowio` in some of our pfb files was incorrect. We are now modifying our code to set these correctly before writing out the pfb file. Addition of these optional parameters to `write_array`/`write_array_pfb` will allow us to use `pftools` directly for this purpose, and phase out our custom `pfspinup` library.