### PR TITLE
Prevent eager CLM export when no clm keys have been defined

### DIFF
--- a/pftools/python/parflow/tools/core.py
+++ b/pftools/python/parflow/tools/core.py
@@ -355,7 +355,7 @@ class Run(BaseRun):
         full_file_path = os.path.abspath(f_name)
         write_dict(self.to_dict(), full_file_path)
 
-        if CLMExporter(self)._using_clm:
+        if CLMExporter(self).can_export:
             # If we are using CLM, write out any other files we need
             CLMExporter(self).write_allowed(settings.WORKING_DIRECTORY)
 

--- a/pftools/python/parflow/tools/export.py
+++ b/pftools/python/parflow/tools/export.py
@@ -453,6 +453,10 @@ class CLMExporter:
         return self._clm_solver.Vegetation.Parameters
 
     @property
+    def _veg_map(self):
+        return self._clm_solver.Vegetation.Map
+
+    @property
     def _land_names(self):
         names = self._veg_params.LandNames
         return names if isinstance(names, list) else names.split()
@@ -567,6 +571,16 @@ class CLMExporter:
     def _using_clm(self):
         # We can add other checks here if needed
         return self.run.Solver.LSM == 'CLM'
+
+    @property
+    def can_export(self):
+        if self._using_clm:
+            land_param_items = self._veg_params.select('{LandCoverParamItem}')
+            land_map_items = self._veg_map.select('LandFrac/{LandFracCoverMapItem}')
+            return (land_param_items and land_map_items and
+                all(x is not None for x in land_param_items + land_map_items))
+
+        return False
 
     @property
     def _import_paths(self):


### PR DESCRIPTION
By default when CLM is used, we always try to export the .dat file
using the pf keys and pfb files. But if those were never defined,
such opperation would fail.

This fix try to guard against it.