### PR TITLE
Support for extra parameters to pfmask-to-pfsol

### DIFF
--- a/docs/pf-keys/tutorials/solid_files.rst
+++ b/docs/pf-keys/tutorials/solid_files.rst
@@ -87,7 +87,7 @@ Full API: SolidFileBuilder
 
 2. ``mask(mask_array)`` - applies the matrix array ``mask_array`` to the SolidFileBuilder object.
 
-3. ``write(self, name, xllcorner=0, yllcorner=0, cellsize=0, vtk=False)`` - writes the ``SolidFileBuilder`` object data to the *.pfsol* file ``name``. The arguments ``xllcorner``, ``yllcorner``, and ``cellsize=0`` help define the size of the solid file domain. If ``vtk`` is set to ``True``, it will write a VTK file ``name.vtk`` that you can view in ParaView or another VTK viewer to check that the solid file is correct.
+3. ``write(self, name, xllcorner=0, yllcorner=0, cellsize=0, vtk=False, extra=None)`` - writes the ``SolidFileBuilder`` object data to the *.pfsol* file ``name``. The arguments ``xllcorner``, ``yllcorner``, and ``cellsize=0`` help define the size of the solid file domain. If ``vtk`` is set to ``True``, it will write a VTK file ``name.vtk`` that you can view in ParaView or another VTK viewer to check that the solid file is correct. If there are any extra arguments you want to pass to the ``pfmask-to-pfsol`` converter in Parflow, specify them using the ``extra`` parameter, as a list of strings.
 
 4. ``for_key(self, geomItem)`` - sets two keys on the ``Run`` object passed in as the ``geomItem`` argument: 1) ``geomItem.InputType = 'SolidFile'`` 2) ``geomItem.FileName = 'name.pfsol'``. ``'name.pfsol'`` is implicitly referenced from the ``name`` argument of the ``write`` method.
 

--- a/pftools/python/parflow/tools/builders.py
+++ b/pftools/python/parflow/tools/builders.py
@@ -104,7 +104,7 @@ class SolidFileBuilder:
         self.patch_ids_side = side_patch_ids
         return self
 
-    def write(self, name, xllcorner=0, yllcorner=0, cellsize=0, vtk=False):
+    def write(self, name, xllcorner=0, yllcorner=0, cellsize=0, vtk=False, extra=None):
         """Writing out pfsol file with optional output to vtk
 
         Args:
@@ -112,6 +112,8 @@ class SolidFileBuilder:
             xllcorner (int, float): coordinate of lower-left corner of x-axis
             yllcorner (int, float): coordinate of lower-left corner of y-axis
             cellsize (int): size of horizontal grid cell for solid file
+            extra (list of strings): Any extra arguments to pass to
+                pfmask-to-pfsol for solid file generation; Default None
         """
         self.name = name
         output_file_path = get_absolute_path(name)
@@ -195,7 +197,8 @@ class SolidFileBuilder:
 
         # Trigger conversion
         print('=== pfmask-to-pfsol ===: BEGIN')
-        extra = []
+        if extra is None:
+            extra = []
         if vtk:
             extra.append('--vtk')
             extra.append(f'{output_file_path[:-6]}.vtk')


### PR DESCRIPTION
We've identified a need to use the `SolidFileBuilder` class to generate `.pfsol` files, but with a customized value of the `z-top` parameter (i.e. invoking the underlying `pfmask-to-pfsol` parflow utility with an additional `--z-top 1000` flag. This minor change should allow us to use the `SolidFileBuilder` class with any custom flags not exposed as explicit attributes in the class.