### PR TITLE
Remove use of MPI_COMM_WORLD

### DIFF
--- a/pfsimulator/amps/cuda/amps.h
+++ b/pfsimulator/amps/cuda/amps.h
@@ -139,7 +139,7 @@
  *
  * @memo Global communication context
  */
-#define amps_CommWorld MPI_COMM_WORLD
+extern MPI_Comm amps_CommWorld;
 
 extern MPI_Comm amps_CommNode;
 extern MPI_Comm amps_CommWrite;
@@ -148,7 +148,7 @@ extern MPI_Comm amps_CommWrite;
 extern MPI_Comm nodeComm;
 extern MPI_Comm writeComm;
 
-/* Global ranks and size of MPI_COMM_WORLD*/
+/* Global ranks and size of amps_CommWorld */
 extern int amps_rank;
 extern int amps_size;
 

--- a/pfsimulator/amps/cuda/amps_finalize.c
+++ b/pfsimulator/amps/cuda/amps_finalize.c
@@ -66,6 +66,7 @@ int amps_Finalize()
   {
     MPI_Comm_free(&amps_CommNode);
     MPI_Comm_free(&amps_CommWrite);
+    MPI_Comm_free(&amps_CommWorld);
 
     MPI_Finalize();
   }
@@ -77,12 +78,5 @@ int amps_Finalize()
     CUDA_ERRCHK(cudaStreamDestroy(amps_device_globals.stream[i]));
   }
 
-#ifdef AMPS_MALLOC_DEBUG
-  /* check out the heap and shut everything down if we are in debug mode */
-#if 0
-  dmalloc_verify(NULL);
-  dmalloc_shutdown();
-#endif
-#endif
   return 0;
 }

--- a/pfsimulator/amps/cuda/amps_init.c
+++ b/pfsimulator/amps/cuda/amps_init.c
@@ -48,6 +48,7 @@ int amps_node_rank;
 int amps_node_size;
 int amps_write_rank;
 int amps_write_size;
+MPI_Comm amps_CommWorld = MPI_COMM_NULL;
 MPI_Comm amps_CommNode = MPI_COMM_NULL;
 MPI_Comm amps_CommWrite = MPI_COMM_NULL;
 
@@ -119,13 +120,14 @@ int amps_Init(int *argc, char **argv[])
 
   MPI_Init(argc, argv);
   amps_mpi_initialized = TRUE;
-
-  MPI_Comm_size(MPI_COMM_WORLD, &amps_size);
-  MPI_Comm_rank(MPI_COMM_WORLD, &amps_rank);
+  
+  MPI_Comm_dup(MPI_COMM_WORLD, &amps_CommWorld);
+  MPI_Comm_size(amps_CommWorld, &amps_size);
+  MPI_Comm_rank(amps_CommWorld, &amps_rank);
 
   /* Create communicator with one rank per compute node */
 #if MPI_VERSION >= 3
-  MPI_Comm_split_type(MPI_COMM_WORLD, MPI_COMM_TYPE_SHARED, 0, MPI_INFO_NULL, &amps_CommNode);
+  MPI_Comm_split_type(amps_CommWorld, MPI_COMM_TYPE_SHARED, 0, MPI_INFO_NULL, &amps_CommNode);
 #else
   /* Split the node level communicator based on Adler32 hash keys of processor name */
   char processor_name[MPI_MAX_PROCESSOR_NAME];
@@ -135,7 +137,7 @@ int amps_Init(int *argc, char **argv[])
   /* Comm split only accepts non-negative numbers */
   /* Not super great for hashing purposes but hoping MPI-3 code will be used on most cases */
   checkSum &= INT_MAX;
-  MPI_Comm_split(MPI_COMM_WORLD, checkSum, amps_rank, &amps_CommNode);
+  MPI_Comm_split(amps_CommWorld, checkSum, amps_rank, &amps_CommNode);
 #endif
   
   MPI_Comm_rank(amps_CommNode, &amps_node_rank);
@@ -149,7 +151,7 @@ int amps_Init(int *argc, char **argv[])
   {
     color = 1;
   }
-  MPI_Comm_split(MPI_COMM_WORLD, color, amps_rank, &amps_CommWrite);
+  MPI_Comm_split(amps_CommWorld, color, amps_rank, &amps_CommWrite);
   if (amps_node_rank == 0)
   {
     MPI_Comm_size(amps_CommWrite, &amps_write_size);
@@ -176,14 +178,14 @@ int amps_Init(int *argc, char **argv[])
     length = strlen(temp_path) + 1;
   }
 
-  MPI_Bcast(&length, 1, MPI_INT, 0, MPI_COMM_WORLD);
+  MPI_Bcast(&length, 1, MPI_INT, 0, amps_CommWorld);
 
   if (amps_rank)
   {
     temp_path = malloc(length);
   }
 
-  MPI_Bcast(temp_path, length, MPI_CHAR, 0, MPI_COMM_WORLD);
+  MPI_Bcast(temp_path, length, MPI_CHAR, 0, amps_CommWorld);
 
   if (chdir(temp_path))
     printf("AMPS Error: can't set working directory to %s", temp_path);
@@ -209,14 +211,16 @@ int amps_Init(int *argc, char **argv[])
 }
 
 /**
- *
  * Initialization when ParFlow is being invoked by another application.
  * This must be done before any other {\em AMPS} calls.
+ *
+ * Assumes ParFlow should use all of MPI_COMM_WORLD as the communication context.
  *
  * {\large Example:}
  * \begin{verbatim}
  * int main( int argc, char *argv)
  * {
+ * <MPI Initialized>
  * amps_EmbeddedInit();
  *
  * amps_Printf("Hello World");
@@ -232,19 +236,43 @@ int amps_Init(int *argc, char **argv[])
  */
 int amps_EmbeddedInit(void)
 {
-  MPI_Comm_size(MPI_COMM_WORLD, &amps_size);
-  MPI_Comm_rank(MPI_COMM_WORLD, &amps_rank);
+  amps_EmbeddedInitComm(MPI_COMM_WORLD);
 
-#ifdef AMPS_STDOUT_NOBUFF
-  setbuf(stdout, NULL);
-#endif
+  return 0;
+}
+
+/**
+ * Initialization when ParFlow is being invoked by another application.
+ * This must be done before any other {\em AMPS} calls.
+ *
+ * ParFlow will use the supplied communication context.
+ *
+ * {\large Example:}
+ * \begin{verbatim}
+ * int main( int argc, char *argv)
+ * {
+ * <MPI Initialized>
+ * amps_EmbeddedInit(MPI_COMM_WORLD);
+ *
+ * amps_Printf("Hello World");
+ *
+ * amps_Finalize();
+ * }
+ * \end{verbatim}
+ *
+ * {\large Notes:}
+ *
+ * @memo Initialize AMPS
+ * @param comm MPI communicator context to use for ParFlow
+ * @return
+ */
+int amps_EmbeddedInitComm(MPI_Comm comm)
+{
+  MPI_Comm_dup(comm, &amps_CommWorld);
+  MPI_Comm_size(amps_CommWorld, &amps_size);
+  MPI_Comm_rank(amps_CommWorld, &amps_rank);
 
   amps_clock_init();
-
-#ifdef AMPS_MALLOC_DEBUG
-  dmalloc_logpath = amps_malloclog;
-  sprintf(dmalloc_logpath, "malloc.log.%04d", amps_Rank(amps_CommWorld));
-#endif
 
   return 0;
 }

--- a/pfsimulator/amps/cuda/amps_proto.h
+++ b/pfsimulator/amps/cuda/amps_proto.h
@@ -36,6 +36,7 @@ amps_File amps_Fopen(char *filename, char *type);
 /* amps_init.c */
 int amps_Init(int *argc, char **argv []);
 int amps_EmbeddedInit(void);
+int amps_EmbeddedInit(MPI_COMM comm);
 
 /* amps_invoice.c */
 void amps_AppendInvoice(amps_Invoice *invoice, amps_Invoice append_invoice);

--- a/pfsimulator/amps/cuda/amps_recv.c
+++ b/pfsimulator/amps/cuda/amps_recv.c
@@ -36,13 +36,13 @@ char *amps_recvb(
 
   MPI_Status status;
 
-  MPI_Probe(src, 0, MPI_COMM_WORLD, &status);
+  MPI_Probe(src, 0, amps_CommWorld, &status);
 
   MPI_Get_count(&status, MPI_BYTE, size);
 
   buf = (char*)malloc((size_t)(*size));
 
-  MPI_Recv(buf, *size, MPI_BYTE, src, 0, MPI_COMM_WORLD, &status);
+  MPI_Recv(buf, *size, MPI_BYTE, src, 0, amps_CommWorld, &status);
 
   return buf;
 }
@@ -91,13 +91,13 @@ int amps_Recv(amps_Comm comm, int source, amps_Invoice invoice)
 
   AMPS_CLEAR_INVOICE(invoice);
 
-  MPI_Probe(source, 0, MPI_COMM_WORLD, &status);
+  MPI_Probe(source, 0, amps_CommWorld, &status);
 
   MPI_Get_count(&status, MPI_BYTE, &size);
 
   buffer = (char*)malloc((size_t)(size));
 
-  MPI_Recv(buffer, size, MPI_BYTE, source, 0, MPI_COMM_WORLD, &status);
+  MPI_Recv(buffer, size, MPI_BYTE, source, 0, amps_CommWorld, &status);
 
   amps_unpack_mpi1(comm, invoice, buffer, size);
 

--- a/pfsimulator/amps/cuda/amps_send.c
+++ b/pfsimulator/amps/cuda/amps_send.c
@@ -38,7 +38,7 @@ int amps_xsend(
 
   MPI_Type_commit(&invoice->mpi_type);
 
-  MPI_Send(buffer, 1, invoice->mpi_type, dest, 0, MPI_COMM_WORLD);
+  MPI_Send(buffer, 1, invoice->mpi_type, dest, 0, amps_CommWorld);
 
   MPI_Type_free(&invoice->mpi_type);
 
@@ -92,7 +92,7 @@ int amps_Send(amps_Comm comm, int dest, amps_Invoice invoice)
 
   MPI_Type_commit(&invoice->mpi_type);
 
-  MPI_Send(MPI_BOTTOM, 1, invoice->mpi_type, dest, 0, MPI_COMM_WORLD);
+  MPI_Send(MPI_BOTTOM, 1, invoice->mpi_type, dest, 0, amps_CommWorld);
 
   MPI_Type_free(&invoice->mpi_type);
 

--- a/pfsimulator/amps/mpi1/amps.h
+++ b/pfsimulator/amps/mpi1/amps.h
@@ -144,7 +144,8 @@
  *
  * @memo Global communication context
  */
-#define amps_CommWorld MPI_COMM_WORLD
+
+extern MPI_Comm amps_CommWorld;
 
 extern MPI_Comm amps_CommNode;
 extern MPI_Comm amps_CommWrite;
@@ -153,7 +154,7 @@ extern MPI_Comm amps_CommWrite;
 extern MPI_Comm nodeComm;
 extern MPI_Comm writeComm;
 
-/* Global ranks and size of MPI_COMM_WORLD*/
+/* Global ranks and size of amps_CommWorld */
 extern int amps_rank;
 extern int amps_size;
 

--- a/pfsimulator/amps/mpi1/amps_exchange.c
+++ b/pfsimulator/amps/mpi1/amps_exchange.c
@@ -101,12 +101,12 @@ amps_Handle amps_IExchangePackage(amps_Package package)
     else{ 
       combuf[0] = NULL;
       size[0] = 1;
-      amps_create_mpi_type(MPI_COMM_WORLD, package->recv_invoices[i]);
+      amps_create_mpi_type(amps_CommWorld, package->recv_invoices[i]);
       MPI_Type_commit(&(package->recv_invoices[i]->mpi_type));
     }
 
     MPI_Irecv(combuf[0], size[0], package->recv_invoices[i]->mpi_type,
-              package->src[i], 0, MPI_COMM_WORLD,
+              package->src[i], 0, amps_CommWorld,
               &(package->recv_requests[i]));
   }
 
@@ -123,7 +123,7 @@ amps_Handle amps_IExchangePackage(amps_Package package)
     else{
       combuf[i] = NULL;
       size[i] = 1;
-      amps_create_mpi_type(MPI_COMM_WORLD, package->send_invoices[i]);
+      amps_create_mpi_type(amps_CommWorld, package->send_invoices[i]);
       MPI_Type_commit(&(package->send_invoices[i]->mpi_type));
     }
   }
@@ -131,7 +131,7 @@ amps_Handle amps_IExchangePackage(amps_Package package)
   {
     amps_gpu_sync_streams(i);
     MPI_Isend(combuf[i], size[i], package->send_invoices[i]->mpi_type,
-              package->dest[i], 0, MPI_COMM_WORLD,
+              package->dest[i], 0, amps_CommWorld,
               &(package->send_requests[i]));
   }
   free(combuf);
@@ -178,12 +178,12 @@ amps_Handle amps_IExchangePackage(amps_Package package)
    *--------------------------------------------------------------------*/
   for (i = 0; i < package->num_recv; i++)
   {
-    amps_create_mpi_type(MPI_COMM_WORLD, package->recv_invoices[i]);
+    amps_create_mpi_type(amps_CommWorld, package->recv_invoices[i]);
 
     MPI_Type_commit(&(package->recv_invoices[i]->mpi_type));
 
     MPI_Irecv(MPI_BOTTOM, 1, package->recv_invoices[i]->mpi_type,
-              package->src[i], 0, MPI_COMM_WORLD,
+              package->src[i], 0, amps_CommWorld,
               &(package->recv_requests[i]));
   }
 
@@ -192,12 +192,12 @@ amps_Handle amps_IExchangePackage(amps_Package package)
    *--------------------------------------------------------------------*/
   for (i = 0; i < package->num_send; i++)
   {
-    amps_create_mpi_type(MPI_COMM_WORLD, package->send_invoices[i]);
+    amps_create_mpi_type(amps_CommWorld, package->send_invoices[i]);
 
     MPI_Type_commit(&(package->send_invoices[i]->mpi_type));
 
     MPI_Isend(MPI_BOTTOM, 1, package->send_invoices[i]->mpi_type,
-              package->dest[i], 0, MPI_COMM_WORLD,
+              package->dest[i], 0, amps_CommWorld,
               &(package->send_requests[i]));
   }
 
@@ -336,7 +336,7 @@ amps_Handle amps_IExchangePackage(amps_Package package)
     {
       for (i = 0; i < package->num_recv; i++)
       {
-        amps_create_mpi_type(MPI_COMM_WORLD, package->recv_invoices[i]);
+        amps_create_mpi_type(amps_CommWorld, package->recv_invoices[i]);
         MPI_Type_commit(&(package->recv_invoices[i]->mpi_type));
 
         // Temporaries needed by insure++
@@ -344,7 +344,7 @@ amps_Handle amps_IExchangePackage(amps_Package package)
         MPI_Request *request_ptr = &(package->recv_requests[i]);
         MPI_Recv_init(MPI_BOTTOM, 1,
                       type,
-                      package->src[i], 0, MPI_COMM_WORLD,
+                      package->src[i], 0, amps_CommWorld,
                       request_ptr);
       }
     }
@@ -356,7 +356,7 @@ amps_Handle amps_IExchangePackage(amps_Package package)
     {
       for (i = 0; i < package->num_send; i++)
       {
-        amps_create_mpi_type(MPI_COMM_WORLD,
+        amps_create_mpi_type(amps_CommWorld,
                              package->send_invoices[i]);
 
         MPI_Type_commit(&(package->send_invoices[i]->mpi_type));
@@ -366,7 +366,7 @@ amps_Handle amps_IExchangePackage(amps_Package package)
         MPI_Request* request_ptr = &(package->send_requests[i]);
         MPI_Ssend_init(MPI_BOTTOM, 1,
                        type,
-                       package->dest[i], 0, MPI_COMM_WORLD,
+                       package->dest[i], 0, amps_CommWorld,
                        request_ptr);
       }
     }

--- a/pfsimulator/amps/mpi1/amps_finalize.c
+++ b/pfsimulator/amps/mpi1/amps_finalize.c
@@ -67,19 +67,13 @@ int amps_Finalize()
   {
     MPI_Comm_free(&amps_CommNode);
     MPI_Comm_free(&amps_CommWrite);
-
+    MPI_Comm_free(&amps_CommWorld);
+    
     MPI_Finalize();
   }
 #if defined(PARFLOW_HAVE_CUDA) || defined(PARFLOW_HAVE_KOKKOS)
   amps_gpu_finalize();
 #endif
 
-#ifdef AMPS_MALLOC_DEBUG
-  /* check out the heap and shut everything down if we are in debug mode */
-#if 0
-  dmalloc_verify(NULL);
-  dmalloc_shutdown();
-#endif
-#endif
   return 0;
 }

--- a/pfsimulator/amps/mpi1/amps_init.c
+++ b/pfsimulator/amps/mpi1/amps_init.c
@@ -48,6 +48,7 @@ int amps_node_rank;
 int amps_node_size;
 int amps_write_rank;
 int amps_write_size;
+MPI_Comm amps_CommWorld = MPI_COMM_NULL;
 MPI_Comm amps_CommNode = MPI_COMM_NULL;
 MPI_Comm amps_CommWrite = MPI_COMM_NULL;
 
@@ -116,12 +117,14 @@ int amps_Init(int *argc, char **argv[])
   MPI_Init(argc, argv);
   amps_mpi_initialized = TRUE;
 
-  MPI_Comm_size(MPI_COMM_WORLD, &amps_size);
-  MPI_Comm_rank(MPI_COMM_WORLD, &amps_rank);
+  MPI_Comm_dup(MPI_COMM_WORLD, &amps_CommWorld);
+
+  MPI_Comm_size(amps_CommWorld, &amps_size);
+  MPI_Comm_rank(amps_CommWorld, &amps_rank);
 
   /* Create communicator with one rank per compute node */
 #if MPI_VERSION >= 3
-  MPI_Comm_split_type(MPI_COMM_WORLD, MPI_COMM_TYPE_SHARED, 0, MPI_INFO_NULL, &amps_CommNode);
+  MPI_Comm_split_type(amps_CommWorld, MPI_COMM_TYPE_SHARED, 0, MPI_INFO_NULL, &amps_CommNode);
 #else
   /* Split the node level communicator based on Adler32 hash keys of processor name */
   char processor_name[MPI_MAX_PROCESSOR_NAME];
@@ -131,7 +134,7 @@ int amps_Init(int *argc, char **argv[])
   /* Comm split only accepts non-negative numbers */
   /* Not super great for hashing purposes but hoping MPI-3 code will be used on most cases */
   checkSum &= INT_MAX;
-  MPI_Comm_split(MPI_COMM_WORLD, checkSum, amps_rank, &amps_CommNode);
+  MPI_Comm_split(amps_CommWorld, checkSum, amps_rank, &amps_CommNode);
 #endif
   
   MPI_Comm_rank(amps_CommNode, &amps_node_rank);
@@ -145,7 +148,7 @@ int amps_Init(int *argc, char **argv[])
   {
     color = 1;
   }
-  MPI_Comm_split(MPI_COMM_WORLD, color, amps_rank, &amps_CommWrite);
+  MPI_Comm_split(amps_CommWorld, color, amps_rank, &amps_CommWrite);
   if (amps_node_rank == 0)
   {
     MPI_Comm_size(amps_CommWrite, &amps_write_size);
@@ -172,14 +175,14 @@ int amps_Init(int *argc, char **argv[])
     length = strlen(temp_path) + 1;
   }
 
-  MPI_Bcast(&length, 1, MPI_INT, 0, MPI_COMM_WORLD);
+  MPI_Bcast(&length, 1, MPI_INT, 0, amps_CommWorld);
 
   if (amps_rank)
   {
     temp_path = malloc(length);
   }
 
-  MPI_Bcast(temp_path, length, MPI_CHAR, 0, MPI_COMM_WORLD);
+  MPI_Bcast(temp_path, length, MPI_CHAR, 0, amps_CommWorld);
 
   if (chdir(temp_path))
     printf("AMPS Error: can't set working directory to %s", temp_path);
@@ -205,14 +208,16 @@ int amps_Init(int *argc, char **argv[])
 }
 
 /**
- *
  * Initialization when ParFlow is being invoked by another application.
  * This must be done before any other {\em AMPS} calls.
+ *
+ * Assumes ParFlow should use all of MPI_COMM_WORLD as the communication context.
  *
  * {\large Example:}
  * \begin{verbatim}
  * int main( int argc, char *argv)
  * {
+ * <MPI Initialized>
  * amps_EmbeddedInit();
  *
  * amps_Printf("Hello World");
@@ -228,21 +233,46 @@ int amps_Init(int *argc, char **argv[])
  */
 int amps_EmbeddedInit(void)
 {
-  MPI_Comm_size(MPI_COMM_WORLD, &amps_size);
-  MPI_Comm_rank(MPI_COMM_WORLD, &amps_rank);
-
-#ifdef AMPS_STDOUT_NOBUFF
-  setbuf(stdout, NULL);
-#endif
-
-  amps_clock_init();
-
-#ifdef AMPS_MALLOC_DEBUG
-  dmalloc_logpath = amps_malloclog;
-  sprintf(dmalloc_logpath, "malloc.log.%04d", amps_Rank(amps_CommWorld));
-#endif
+  amps_EmbeddedInitComm(MPI_COMM_WORLD);
 
   return 0;
 }
+
+/**
+ * Initialization when ParFlow is being invoked by another application.
+ * This must be done before any other {\em AMPS} calls.
+ *
+ * ParFlow will use the supplied communication context.
+ *
+ * {\large Example:}
+ * \begin{verbatim}
+ * int main( int argc, char *argv)
+ * {
+ * <MPI Initialized>
+ * amps_EmbeddedInit(MPI_COMM_WORLD);
+ *
+ * amps_Printf("Hello World");
+ *
+ * amps_Finalize();
+ * }
+ * \end{verbatim}
+ *
+ * {\large Notes:}
+ *
+ * @memo Initialize AMPS
+ * @param comm MPI communicator context to use for ParFlow
+ * @return
+ */
+int amps_EmbeddedInitComm(MPI_Comm comm)
+{
+  MPI_Comm_dup(comm, &amps_CommWorld);
+  MPI_Comm_size(amps_CommWorld, &amps_size);
+  MPI_Comm_rank(amps_CommWorld, &amps_rank);
+
+  amps_clock_init();
+
+  return 0;
+}
+
 
 

--- a/pfsimulator/amps/mpi1/amps_proto.h
+++ b/pfsimulator/amps/mpi1/amps_proto.h
@@ -41,6 +41,7 @@ int amps_gpupacking(int action, amps_Invoice inv, int inv_num, char **buffer_out
 /* amps_init.c */
 int amps_Init(int *argc, char **argv []);
 int amps_EmbeddedInit(void);
+int amps_EmbeddedInitComm(MPI_Comm com);
 
 /* amps_invoice.c */
 void amps_AppendInvoice(amps_Invoice *invoice, amps_Invoice append_invoice);

--- a/pfsimulator/amps/mpi1/amps_recv.c
+++ b/pfsimulator/amps/mpi1/amps_recv.c
@@ -36,13 +36,13 @@ char *amps_recvb(
 
   MPI_Status status;
 
-  MPI_Probe(src, 0, MPI_COMM_WORLD, &status);
+  MPI_Probe(src, 0, amps_CommWorld, &status);
 
   MPI_Get_count(&status, MPI_BYTE, size);
 
   buf = (char*)malloc((size_t)(*size));
 
-  MPI_Recv(buf, *size, MPI_BYTE, src, 0, MPI_COMM_WORLD, &status);
+  MPI_Recv(buf, *size, MPI_BYTE, src, 0, amps_CommWorld, &status);
 
   return buf;
 }
@@ -91,13 +91,13 @@ int amps_Recv(amps_Comm comm, int source, amps_Invoice invoice)
 
   AMPS_CLEAR_INVOICE(invoice);
 
-  MPI_Probe(source, 0, MPI_COMM_WORLD, &status);
+  MPI_Probe(source, 0, amps_CommWorld, &status);
 
   MPI_Get_count(&status, MPI_BYTE, &size);
 
   buffer = (char*)malloc((size_t)(size));
 
-  MPI_Recv(buffer, size, MPI_BYTE, source, 0, MPI_COMM_WORLD, &status);
+  MPI_Recv(buffer, size, MPI_BYTE, source, 0, amps_CommWorld, &status);
 
   amps_unpack(comm, invoice, buffer, size);
 

--- a/pfsimulator/amps/mpi1/amps_send.c
+++ b/pfsimulator/amps/mpi1/amps_send.c
@@ -38,7 +38,7 @@ int amps_xsend(
 
   MPI_Type_commit(&invoice->mpi_type);
 
-  MPI_Send(buffer, 1, invoice->mpi_type, dest, 0, MPI_COMM_WORLD);
+  MPI_Send(buffer, 1, invoice->mpi_type, dest, 0, amps_CommWorld);
 
   MPI_Type_free(&invoice->mpi_type);
 
@@ -92,7 +92,7 @@ int amps_Send(amps_Comm comm, int dest, amps_Invoice invoice)
 
   MPI_Type_commit(&invoice->mpi_type);
 
-  MPI_Send(MPI_BOTTOM, 1, invoice->mpi_type, dest, 0, MPI_COMM_WORLD);
+  MPI_Send(MPI_BOTTOM, 1, invoice->mpi_type, dest, 0, amps_CommWorld);
 
   MPI_Type_free(&invoice->mpi_type);
 

--- a/pfsimulator/amps/smpi/amps.h
+++ b/pfsimulator/amps/smpi/amps.h
@@ -143,13 +143,13 @@
  *
  * @memo Global communication context
  */
-#define amps_CommWorld MPI_COMM_WORLD
+extern MPI_Comm amps_CommWorld;
 
 /* Communicators for I/O */
 extern MPI_Comm amps_CommNode;
 extern MPI_Comm amps_CommWrite;
 
-/* Global ranks and size of MPI_COMM_WORLD*/
+/* Global ranks and size of amps_CommWorld */
 extern int amps_rank;
 extern int amps_size;
 

--- a/pfsimulator/amps/smpi/amps_finalize.c
+++ b/pfsimulator/amps/smpi/amps_finalize.c
@@ -67,16 +67,10 @@ int amps_Finalize()
   {
     MPI_Comm_free(&amps_CommNode);
     MPI_Comm_free(&amps_CommWrite);
+    MPI_Comm_free(&amps_CommWorld);
 
     MPI_Finalize();
   }
 
-#ifdef AMPS_MALLOC_DEBUG
-  /* check out the heap and shut everything down if we are in debug mode */
-#if 0
-  dmalloc_verify(NULL);
-  dmalloc_shutdown();
-#endif
-#endif
   return 0;
 }

--- a/pfsimulator/amps/smpi/amps_init.c
+++ b/pfsimulator/amps/smpi/amps_init.c
@@ -48,6 +48,7 @@ int amps_node_rank;
 int amps_node_size;
 int amps_write_rank;
 int amps_write_size;
+MPI_Comm amps_CommWorld = MPI_COMM_NULL;
 MPI_Comm amps_CommNode = MPI_COMM_NULL;
 MPI_Comm amps_CommWrite = MPI_COMM_NULL;
 
@@ -116,12 +117,14 @@ int amps_Init(int *argc, char **argv[])
   MPI_Init(argc, argv);
   amps_mpi_initialized = TRUE;
 
-  MPI_Comm_size(MPI_COMM_WORLD, &amps_size);
-  MPI_Comm_rank(MPI_COMM_WORLD, &amps_rank);
+  MPI_Comm_dup(MPI_COMM_WORLD, &amps_CommWorld);
+
+  MPI_Comm_size(amps_CommWorld, &amps_size);
+  MPI_Comm_rank(amps_CommWorld, &amps_rank);
 
   /* Create communicator with one rank per compute node */
 #if MPI_VERSION >= 3
-  MPI_Comm_split_type(MPI_COMM_WORLD, MPI_COMM_TYPE_SHARED, 0, MPI_INFO_NULL, &amps_CommNode);
+  MPI_Comm_split_type(amps_CommWorld, MPI_COMM_TYPE_SHARED, 0, MPI_INFO_NULL, &amps_CommNode);
 #else
   /* Split the node level communicator based on Adler32 hash keys of processor name */
   char processor_name[MPI_MAX_PROCESSOR_NAME];
@@ -132,7 +135,7 @@ int amps_Init(int *argc, char **argv[])
   /* Comm split only accepts non-negative numbers */
   /* Not super great for hashing purposes but hoping MPI-3 code will be used on most cases */
   checkSum &= INT_MAX;
-  MPI_Comm_split(MPI_COMM_WORLD, checkSum, amps_rank, &amps_CommNode);
+  MPI_Comm_split(amps_CommWorld, checkSum, amps_rank, &amps_CommNode);
 #endif
   
   MPI_Comm_rank(amps_CommNode, &amps_node_rank);
@@ -146,7 +149,7 @@ int amps_Init(int *argc, char **argv[])
   {
     color = 1;
   }
-  MPI_Comm_split(MPI_COMM_WORLD, color, amps_rank, &amps_CommWrite);
+  MPI_Comm_split(amps_CommWorld, color, amps_rank, &amps_CommWrite);
   if (amps_node_rank == 0)
   {
     MPI_Comm_size(amps_CommWrite, &amps_write_size);
@@ -173,14 +176,14 @@ int amps_Init(int *argc, char **argv[])
     length = strlen(temp_path) + 1;
   }
 
-  MPI_Bcast(&length, 1, MPI_INT, 0, MPI_COMM_WORLD);
+  MPI_Bcast(&length, 1, MPI_INT, 0, amps_CommWorld);
 
   if (amps_rank)
   {
     temp_path = malloc(length);
   }
 
-  MPI_Bcast(temp_path, length, MPI_CHAR, 0, MPI_COMM_WORLD);
+  MPI_Bcast(temp_path, length, MPI_CHAR, 0, amps_CommWorld);
 
   if (chdir(temp_path))
     printf("AMPS Error: can't set working directory to %s", temp_path);
@@ -205,15 +208,18 @@ int amps_Init(int *argc, char **argv[])
   return 0;
 }
 
+
 /**
- *
  * Initialization when ParFlow is being invoked by another application.
  * This must be done before any other {\em AMPS} calls.
+ *
+ * Assumes ParFlow should use all of MPI_COMM_WORLD as the communication context.
  *
  * {\large Example:}
  * \begin{verbatim}
  * int main( int argc, char *argv)
  * {
+ * <MPI Initialized>
  * amps_EmbeddedInit();
  *
  * amps_Printf("Hello World");
@@ -229,22 +235,45 @@ int amps_Init(int *argc, char **argv[])
  */
 int amps_EmbeddedInit(void)
 {
-  MPI_Comm_size(MPI_COMM_WORLD, &amps_size);
-  MPI_Comm_rank(MPI_COMM_WORLD, &amps_rank);
-
-#ifdef AMPS_STDOUT_NOBUFF
-  setbuf(stdout, NULL);
-#endif
-
-  amps_clock_init();
-
-#ifdef AMPS_MALLOC_DEBUG
-  dmalloc_logpath = amps_malloclog;
-  sprintf(dmalloc_logpath, "malloc.log.%04d", amps_Rank(amps_CommWorld));
-#endif
+  amps_EmbeddedInitComm(MPI_COMM_WORLD);
 
   return 0;
 }
 
+/**
+ * Initialization when ParFlow is being invoked by another application.
+ * This must be done before any other {\em AMPS} calls.
+ *
+ * ParFlow will use the supplied communication context.
+ *
+ * {\large Example:}
+ * \begin{verbatim}
+ * int main( int argc, char *argv)
+ * {
+ * <MPI Initialized>
+ * amps_EmbeddedInit(MPI_COMM_WORLD);
+ *
+ * amps_Printf("Hello World");
+ *
+ * amps_Finalize();
+ * }
+ * \end{verbatim}
+ *
+ * {\large Notes:}
+ *
+ * @memo Initialize AMPS
+ * @param comm MPI communicator context to use for ParFlow
+ * @return
+ */
+int amps_EmbeddedInitComm(MPI_Comm comm)
+{
+  MPI_Comm_dup(comm, &amps_CommWorld);
+  MPI_Comm_size(amps_CommWorld, &amps_size);
+  MPI_Comm_rank(amps_CommWorld, &amps_rank);
+
+  amps_clock_init();
+
+  return 0;
+}
 
 

--- a/pfsimulator/amps/smpi/amps_proto.h
+++ b/pfsimulator/amps/smpi/amps_proto.h
@@ -37,6 +37,7 @@ amps_File amps_Fopen (char *filename, char *type);
 int MAIN__ (void);
 int amps_Init (int *argc, char **argv []);
 int amps_EmbeddedInit(void);
+int amps_EmbeddedInitComm(MPI_Comm com);
 
 /* amps_invoice.c */
 void amps_AppendInvoice (amps_Invoice *invoice, amps_Invoice append_invoice);

--- a/pfsimulator/amps/smpi/amps_recv.c
+++ b/pfsimulator/amps/smpi/amps_recv.c
@@ -36,13 +36,13 @@ int *size;
 
   MPI_Status status;
 
-  MPI_Probe(src, 0, MPI_COMM_WORLD, &status);
+  MPI_Probe(src, 0, amps_CommWorld, &status);
 
   MPI_Get_count(&status, MPI_BYTE, size);
 
   buf = malloc(*size);
 
-  MPI_Recv(buf, *size, MPI_BYTE, src, 0, MPI_COMM_WORLD, &status);
+  MPI_Recv(buf, *size, MPI_BYTE, src, 0, amps_CommWorld, &status);
 
   return buf;
 }
@@ -91,7 +91,7 @@ int amps_Recv(amps_Comm comm, int source, amps_Invoice invoice)
 
   AMPS_CLEAR_INVOICE(invoice);
 
-  MPI_Probe(source, 0, MPI_COMM_WORLD, &status);
+  MPI_Probe(source, 0, amps_CommWorld, &status);
 
   MPI_Get_count(&status, MPI_BYTE, &size);
 
@@ -101,7 +101,7 @@ int amps_Recv(amps_Comm comm, int source, amps_Invoice invoice)
  * amps_Printf("Recv buffer: %x from node %d\n", buffer, source);
  */
 
-  MPI_Recv(buffer, size, MPI_BYTE, source, 0, MPI_COMM_WORLD, &status);
+  MPI_Recv(buffer, size, MPI_BYTE, source, 0, amps_CommWorld, &status);
 
   amps_unpack(comm, invoice, buffer);
 

--- a/pfsimulator/amps/smpi/amps_send.c
+++ b/pfsimulator/amps/smpi/amps_send.c
@@ -34,7 +34,7 @@ int dest;
 char *buffer;
 int size;
 {
-  MPI_Send(buffer, size, MPI_BYTE, dest, 0, MPI_COMM_WORLD);
+  MPI_Send(buffer, size, MPI_BYTE, dest, 0, amps_CommWorld);
 
   return 0;
 }
@@ -92,7 +92,7 @@ int amps_Send(amps_Comm comm, int dest, amps_Invoice invoice)
  * amps_Printf("amps_Send: %d bytes to node %d from buffer %x\n", size, dest, buffer);
  */
 
-  MPI_Send(buffer, size, MPI_BYTE, dest, 0, MPI_COMM_WORLD);
+  MPI_Send(buffer, size, MPI_BYTE, dest, 0, amps_CommWorld);
 
   amps_ClearInvoice(invoice);
 


### PR DESCRIPTION
Enable use of a communicator other than MPI_COMM_WORLD for more general embedding.
Meet IDEAS Watersheds best practices policy.