### PR TITLE
Remove reference to parflowio, relax requirement on numba

### DIFF
--- a/pftools/python/parflow/tools/io.py
+++ b/pftools/python/parflow/tools/io.py
@@ -22,7 +22,16 @@ from functools import partial
 import itertools
 import json
 from pathlib import Path
-from numba import jit
+try:
+    from numba import jit
+except ImportError:
+    # Some systems may not have numba capabilities
+    def jit(self, function, *args, **kwargs):
+        """Dummy decorator, does nothing"""
+        def wrapper(*args, **kwargs):
+            function(*args, **kwargs)
+        return wrapper
+
 from numbers import Number
 import numpy as np
 import struct
@@ -1272,18 +1281,7 @@ class DataAccessor:
     # ---------------------------------------------------------------------------
 
     def _pfb_to_array(self, file_path):
-        from parflowio.pyParflowio import PFData
-
-        array = None
-        if file_path:
-            full_path = get_absolute_path(file_path)
-            # FIXME do something with selector inside parflow-io
-            pfb_data = PFData(full_path)
-            pfb_data.loadHeader()
-            pfb_data.loadData()
-            array = pfb_data.moveDataArray()
-
-        return array
+        return read_pfb(get_absolute_path(file_path))
 
     # ---------------------------------------------------------------------------
     # time

--- a/pftools/python/setup.py
+++ b/pftools/python/setup.py
@@ -23,20 +23,27 @@ setup(
     packages=find_packages(),
     install_requires=[
         'pyyaml==5.4',
-        'numpy',
-        'xarray',
-        'numba',
-        'dask',
-        'imageio>=2.9.0'
     ],
     include_package_data=True,
     extras_require={
         'all': [
-            'imageio>=2.9.0',
+            'imageio>=2.9.0'
+            'numpy',
+            'xarray',
+            'numba',
+            'dask',
         ],
         'pfsol': [
             'imageio>=2.9.0'
-        ]
+        ],
+        'io':[
+            'numpy',
+            'xarray',
+            'dask',
+        ],
+        'fastio': [
+            'numba',
+        ],
     },
     entry_points={
         'xarray.backends': [

--- a/pftools/python/setup.py
+++ b/pftools/python/setup.py
@@ -7,7 +7,7 @@ README = (HERE / "README.md").read_text()
 
 setup(
     name='pftools',
-    version="1.2.0",
+    version="1.3.1",
     description=('A Python package creating an interface with the ParFlow '
                  'hydrologic model.'),
     long_description=README,
@@ -22,7 +22,7 @@ setup(
     keywords=['ParFlow', 'groundwater model', 'surface water model'],
     packages=find_packages(),
     install_requires=[
-        'pyyaml==5.4',
+        'pyyaml>=5.4',
     ],
     include_package_data=True,
     extras_require={


### PR DESCRIPTION
This PR fixes a leftover reference to parflowio that wasn't removed in #365. It also makes the numba dependency optional as there are still some issues with installing on Mac M1 based machines.