### PR TITLE
PFTools 1.3.4

### DIFF
--- a/pftools/python/setup.py
+++ b/pftools/python/setup.py
@@ -7,7 +7,7 @@ README = (HERE / "README.md").read_text()
 
 setup(
     name='pftools',
-    version="1.3.3",
+    version="1.3.4",
     description=('A Python package creating an interface with the ParFlow '
                  'hydrologic model.'),
     long_description=README,


### PR DESCRIPTION
I had to bump the PFTools version to `1.3.4` (version `1.3.3` was released incorrectly). This change now reflects the latest working version on pypi.