### PR TITLE
Update Python version; using features from 3.6

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -590,7 +590,7 @@ endif()
 
 option(PARFLOW_ENABLE_PYTHON "Build python module for running ParFlow" "FALSE")
 if (PARFLOW_ENABLE_PYTHON)
-  find_package(Python3 3.3 QUIET REQUIRED COMPONENTS Interpreter)
+  find_package(Python3 3.6 QUIET REQUIRED COMPONENTS Interpreter)
   set(PARFLOW_PYTHON ${Python3_EXECUTABLE})
   set(PARFLOW_PYTHON_DEPENDS)
 


### PR DESCRIPTION
Require Python 3.6 in CMake

fixes #376 