### PR TITLE
Increased input database maximum value size from 4097 to 65536

### DIFF
--- a/pfsimulator/parflow_lib/input_database.c
+++ b/pfsimulator/parflow_lib/input_database.c
@@ -162,11 +162,11 @@ IDB *IDB_NewDB(char *filename)
     amps_SFBCast(amps_CommWorld, file, invoice);
     if ((value_len + 1) > IDB_MAX_VALUE_LEN) {
       key[key_len] = '\0';
-      char idb_max_value_string[1028];
-      sprintf(idb_max_value_string, "%d", IDB_MAX_VALUE_LEN-1);
+      char s[128];
+      sprintf(s, "%d", IDB_MAX_VALUE_LEN-1);
       InputError("Error: The value associated with input database "
                  "key <%s> is too long. The maximum length is %s. ",
-                 key, idb_max_value_string); 
+                 key, s); 
     }
     key[key_len] = '\0';
     value[value_len] = '\0';

--- a/pfsimulator/parflow_lib/input_database.c
+++ b/pfsimulator/parflow_lib/input_database.c
@@ -162,9 +162,11 @@ IDB *IDB_NewDB(char *filename)
     amps_SFBCast(amps_CommWorld, file, invoice);
     if ((value_len + 1) > IDB_MAX_VALUE_LEN) {
       key[key_len] = '\0';
+      char idb_max_value_string[1028];
+      sprintf(idb_max_value_string, "%d", IDB_MAX_VALUE_LEN-1);
       InputError("Error: The value associated with input database "
-                 "key '%s' is too long. The maximum length is %d. ",
-                 key, IDB_MAX_VALUE_LEN-1); 
+                 "key <%s> is too long. The maximum length is %s. ",
+                 key, idb_max_value_string); 
     }
     key[key_len] = '\0';
     value[value_len] = '\0';

--- a/pfsimulator/parflow_lib/input_database.c
+++ b/pfsimulator/parflow_lib/input_database.c
@@ -154,13 +154,18 @@ IDB *IDB_NewDB(char *filename)
   amps_FreeInvoice(invoice);
 
   /* Read in each of the items in the file and put them in the HBT */
-
   invoice = amps_NewInvoice("%i%&c%i%&c", &key_len, &key_len, key,
                             &value_len, &value_len, value);
   for (i = 0; i < num_entries; i++)
   {
     /* Read the key and value from the input file */
     amps_SFBCast(amps_CommWorld, file, invoice);
+    if ((value_len + 1) > IDB_MAX_VALUE_LEN) {
+      key[key_len] = '\0';
+      InputError("Error: The value associated with input database "
+                 "key '%s' is too long. The maximum length is %d. ",
+                 key, IDB_MAX_VALUE_LEN-1); 
+    }
     key[key_len] = '\0';
     value[value_len] = '\0';
 

--- a/pfsimulator/parflow_lib/input_database.h
+++ b/pfsimulator/parflow_lib/input_database.h
@@ -41,7 +41,7 @@
  * Maximum length for the value (including the trailing NUL).
  * User can thus enter 4096 characters.
  */
-#define IDB_MAX_VALUE_LEN 4097
+#define IDB_MAX_VALUE_LEN 65536
 
 /**
  * Entry value for the HBT.  Contains the key and the value pair.


### PR DESCRIPTION
### Update summary:

the maximum input database value length was increased from 4097 to 65536. A bounds check is performed that emits a helpful error message when a database value is too big.

4097 to 65536 seems like a big increase, but IDB_MAX_VALUE_LEN is only used once as a buffer size to read database entries. The char pointers are then null-terminated and passed to IDB_NewEntry, where strdup mallocs an appropriate string size. The strings are still freed in the same place.

### Checks performed:

1. All tests pass on my personal laptop configured with Hypre and CLM, except for those that exceed my available processors.
2. A modified copy of impes.simple.tcl was configured with a key of size 65535. It ran without segfaulting.
3. A modified copy of impes.simple.tcl was configured with a key of size 65536. It produced the desired error message in the output log:
_"Node 0: Error: The value associated with input database key 'A.Very.Long.Key' is too long. The maximum length is 65535. "_