### PR TITLE
vshape should be a 1d array instead of a 2d array.

### DIFF
--- a/pfsimulator/amps/oas3/oas_pfl_define.F90
+++ b/pfsimulator/amps/oas3/oas_pfl_define.F90
@@ -59,7 +59,7 @@ REAL (KIND=8), INTENT(IN)                  ::                   &
 CHARACTER(len=4)                           ::  clgrd
 INTEGER                                    ::  il_flag            ! Flag for grid writing by proc 0
 INTEGER                                    ::  var_nodims(2)      ! used in prism_def_var_proto
-INTEGER                                    ::  vshape(2,2)        ! Shape of array passed to PSMILe 
+INTEGER                                    ::  vshape(4)          ! Shape of array passed to PSMILe 
                                                                   ! 2 x field rank (= 4 because fields are of rank = 2)
 INTEGER                                    ::  dim_paral          ! Type of partition
 INTEGER, POINTER                           ::  il_paral(:)        ! Define process partition 
@@ -222,10 +222,10 @@ INTEGER                                    ::  status, pflncid,  &!
 ! Define the shape of valid region w/o any halo between cpus
 !++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
- vshape(1,1)    = 1
- vshape(2,1)    = nx
- vshape(1,2)    = 1
- vshape(2,2)    = ny
+ vshape(1)    = 1
+ vshape(2)    = nx
+ vshape(3)    = 1
+ vshape(4)    = ny
 
  CALL prism_def_partition_proto ( part_id, il_paral, ierror )
  IF (ierror /= 0) CALL prism_abort_proto(comp_id, 'model1', 'Failure in prism_def_partition_proto')
@@ -307,7 +307,7 @@ INTEGER                                    ::  status, pflncid,  &!
 
  !Allocate memory for data exchange and initilize it
  !
- ALLOCATE( bufz(vshape(1,1):vshape(2,1), vshape(1,2):vshape(2,2)), stat = ierror )
+ ALLOCATE( bufz(vshape(1):vshape(2), vshape(3):vshape(4)), stat = ierror )
  IF (ierror > 0) CALL prism_abort_proto(comp_id, 'oas_pfl_define', 'Failure in allocating bufz' )
 
  ! Allocate array to store received fields between two coupling steps


### PR DESCRIPTION
Its attributes are specified as `[INTEGER, DIMENSION(2*id var nodims(1)), IN]`
based on the [OASIS3-MCT docs](https://gitlab.com/cerfacs/oasis3-mct/-/blob/OASIS3-MCT_3.1/doc/oasis3mct_UserGuide.pdf):

```
• CALL oasis def var (var id, name, il part id, var nodims, kinout,
var type, kinfo) or
• CALL oasis def var (var id, name, il part id, var nodims, kinout,
var actual shape, var type, kinfo) or
• CALL prism def var proto(var id, name, il part id, var nodims, kinout,
var type, kinfo) or
• CALL prism def var proto(var id, name, il part id, var nodims, kinout,
var actual shape, var type, kinfo)
.
.
.
– var actual shape [INTEGER, DIMENSION(2*id var nodims(1)), IN]: is not
used anymore. The interface has recently been overloaded, and this argument is no longer re-
quired. But for backwards compatibility, it can still be passed; if so, it has to be a vector of
integers of any length (for simplicity we advise to pass a vector of length 1).
```