### PR TITLE
Minor improvements/bugfix for python IO

### DIFF
--- a/pftools/python/CHANGELOG.md
+++ b/pftools/python/CHANGELOG.md
@@ -1,8 +1,13 @@
 # Changelog for Python-PFTools (pftools package)
 
-## Unreleased:
+## v1.3.6 (Unreleased):
 
 - Metadata keys and processing of CLM files
+- Fix a bug on xarray indexing which require squeezing out multiple dimensions
+- Add the ability to give keys to the pf.read_pfb function for subsetting
+- Performance improvement with xarray by removing dask delayed call, which
+  caused threadlocks. Lazy loading is implemented natively now with changes to
+  the indexing methods.
 
 ## v1.0.0 (released 2020-11-12):
 

--- a/pftools/python/parflow/tools/io.py
+++ b/pftools/python/parflow/tools/io.py
@@ -55,12 +55,22 @@ except ImportError:
     from yaml import Dumper as YAMLDumper
 
 
-def read_pfb(file: str, mode: str='full', z_first: bool=True):
+def read_pfb(file: str, keys: dict=None, mode: str='full', z_first: bool=True):
     """
     Read a single pfb file, and return the data therein
 
     :param file:
         The file to read.
+    :param keys:
+        A set of keys for indexing subarrays of the full pfb. Optional.
+        This is mainly a trick for interfacing with xarray, but the format
+        of the keys is:
+
+            ::
+            {'x': {'start': start_x, 'stop': end_x},
+             'y': {'start': start_y, 'stop': end_y},
+             'z': {'start': start_z, 'stop': end_z}}
+
     :param mode:
         The mode for the reader. See ``ParflowBinaryReader::read_all_subgrids``
         for more information about what modes are available.
@@ -68,7 +78,21 @@ def read_pfb(file: str, mode: str='full', z_first: bool=True):
         An nd array containing the data from the pfb file.
     """
     with ParflowBinaryReader(file) as pfb:
-        data = pfb.read_all_subgrids(mode=mode, z_first=z_first)
+        if not keys:
+            data = pfb.read_all_subgrids(mode=mode, z_first=z_first)
+        else:
+            base_header = pfb.header
+            start_x = keys['x']['start'] or 0
+            start_y = keys['y']['start'] or 0
+            start_z = keys['z']['start'] or 0
+            stop_x = keys['x']['stop'] or base_header['nx']
+            stop_y = keys['y']['stop'] or base_header['ny']
+            stop_z = keys['z']['stop'] or base_header['nz']
+            nx = np.max([stop_x - start_x, 1])
+            ny = np.max([stop_y - start_y, 1])
+            nz = np.max([stop_z - start_z, 1])
+            data = pfb.read_subarray(
+                        start_x, start_y, start_z, nx, ny, nz, z_first=z_first)
     return data
 
 
@@ -1202,7 +1226,7 @@ def _read_vegm(file_name):
     x_dim = int(last_line_split[0])
     y_dim = int(last_line_split[1])
     z_dim = len(last_line_split) - 2
-    
+
     # To be consistent with ParFlow-python xy indexing, x should represent columns and y rows
     vegm_array = np.zeros((y_dim, x_dim, z_dim))
     # Assume first two lines are comments

--- a/pftools/python/parflow/tools/io.py
+++ b/pftools/python/parflow/tools/io.py
@@ -568,8 +568,15 @@ class ParflowBinaryReader:
                 if end in c: break
             return np.arange(s, e+1)
 
+        if not start_x:
+            start_x = 0
+        if not start_y:
+            start_y = 0
+        if not start_z:
+            start_z = 0
         if not nz:
             nz = self.header['nz']
+
         end_x = start_x + nx
         end_y = start_y + ny
         end_z = start_z + nz

--- a/pftools/python/parflow/tools/pf_backend.py
+++ b/pftools/python/parflow/tools/pf_backend.py
@@ -11,7 +11,6 @@ from pprint import pprint
 from . import util
 from .io import ParflowBinaryReader, read_pfb_sequence, read_pfb
 from collections.abc import Iterable
-from dask import delayed
 from typing import Mapping, List, Union
 from xarray.backends  import BackendEntrypoint, BackendArray
 from xarray.core import indexing
@@ -432,11 +431,9 @@ class ParflowBackendEntrypoint(BackendEntrypoint):
         return False
 
 
-@delayed
 def _getitem_no_state(file_or_seq, key, dims, mode, z_first=True, z_is='z'):
     """
-    Base functionality for actually getting data out of PFB files. This
-    function has been wrapped by @delayed, making it execute lazily.
+    Base functionality for actually getting data out of PFB files.
 
     :param file_or_seq:
         File or files that should be read from.
@@ -613,10 +610,9 @@ class ParflowBackendArray(BackendArray):
     def _getitem(self, key: tuple) -> np.ndarray:
         """Mapping between keys to the actual data"""
         size = self._size_from_key(key)
-        sub = delayed(_getitem_no_state)(
+        sub = _getitem_no_state(
                 self.file_or_seq, key, self.dims, self.mode,
                 self.z_first, self.z_is)
-        sub = dask.array.from_delayed(sub, size, dtype=np.float64)
         return sub
 
     def _size_from_key(self, key):

--- a/pftools/python/parflow/tools/pf_backend.py
+++ b/pftools/python/parflow/tools/pf_backend.py
@@ -26,14 +26,14 @@ class ParflowBackendEntrypoint(BackendEntrypoint):
     """
 
     open_dataset_parameters = [
-            "filename_or_obj",
-            "drop_variables",
-            "name",
-            "meta_yaml",
-            "read_inputs",
-            "read_outputs",
-            "inferred_dims",
-            "inferred_shape"
+        "filename_or_obj",
+        "drop_variables",
+        "name",
+        "meta_yaml",
+        "read_inputs",
+        "read_outputs",
+        "inferred_dims",
+        "inferred_shape"
     ]
 
     def open_dataset(
@@ -347,7 +347,7 @@ class ParflowBackendEntrypoint(BackendEntrypoint):
                 z_first=z_first,
                 z_is=z_is
         ))
-        var = xr.Variable(dims, data, ).squeeze()
+        var = xr.Variable(dims, data, )
         return var
 
     def load_sequence_of_pfb(
@@ -461,12 +461,12 @@ def _getitem_no_state(file_or_seq, key, dims, mode, z_first=True, z_is='z'):
 
         with ParflowBinaryReader(file_or_seq) as pfd:
             sub = pfd.read_subarray(
-                start_x=int(accessor['x']['start']),
-                start_y=int(accessor['y']['start']),
-                start_z=int(accessor['z']['start']),
-                nx=int(accessor['x']['stop']),
-                ny=int(accessor['y']['stop']),
-                nz=int(accessor['z']['stop']),
+                start_x=accessor['x']['start'],
+                start_y=accessor['y']['start'],
+                start_z=accessor['z']['start'],
+                nx=accessor['x']['stop'],
+                ny=accessor['y']['stop'],
+                nz=accessor['z']['stop'],
                 z_first=z_first
             )
         sub = sub[accessor[d[0]]['indices'],

--- a/pftools/python/parflow/tools/util.py
+++ b/pftools/python/parflow/tools/util.py
@@ -50,9 +50,9 @@ def _key_to_explicit_accessor(key: Union[slice, int, Iterable]) -> dict:
         }
     elif isinstance(key, Iterable):
         return {
-            'start': np.min(key),
-            'stop': np.max(key)+1,
-            'indices': key - np.min(key),
+            'start': int(np.min(key)),
+            'stop': int(np.max(key)+1),
+            'indices': int(key - np.min(key)),
             'squeeze': False
         }
 

--- a/pftools/python/parflow/tools/util.py
+++ b/pftools/python/parflow/tools/util.py
@@ -45,7 +45,7 @@ def _key_to_explicit_accessor(key: Union[slice, int, Iterable]) -> dict:
         return {
             'start': key,
             'stop': key+1,
-            'indices': [0],
+            'indices': slice(0, 1),
             'squeeze': True
         }
     elif isinstance(key, Iterable):

--- a/pftools/python/setup.py
+++ b/pftools/python/setup.py
@@ -7,7 +7,7 @@ README = (HERE / "README.md").read_text()
 
 setup(
     name='pftools',
-    version="1.3.5",
+    version="1.3.6",
     description=('A Python package creating an interface with the ParFlow '
                  'hydrologic model.'),
     long_description=README,


### PR DESCRIPTION
- Fix a bug on xarray indexing which require squeezing out multiple dimensions
- Add the ability to give keys to the pf.read_pfb function for subsetting
- Performance improvement with xarray by removing dask delayed call, which
  caused threadlocks. Lazy loading is implemented natively now with changes to
  the indexing methods.
- Fixes #388 