### PR TITLE
Starting from CUB 1.14, CUB_NS_QUALIFIER macro must be specified

### DIFF
--- a/pfsimulator/third_party/cub/util_namespace.cuh
+++ b/pfsimulator/third_party/cub/util_namespace.cuh
@@ -44,3 +44,7 @@
 #ifndef CUB_NS_POSTFIX
 #define CUB_NS_POSTFIX
 #endif
+
+#ifndef CUB_NS_QUALIFIER
+#define CUB_NS_QUALIFIER ::cub
+#endif


### PR DESCRIPTION
This PR fixes the compile error when using CUDA 11.5 or later. 

```
In file included from /opt/software/CUDA/11.5/targets/x86_64-linux/include/thrust/system/cuda/config.h:73,
                 from /opt/software/CUDA/11.5/targets/x86_64-linux/include/thrust/system/cuda/detail/execution_policy.h:35,
                 from /opt/software/CUDA/11.5/targets/x86_64-linux/include/thrust/iterator/detail/device_system_tag.h:23,
                 from /opt/software/CUDA/11.5/targets/x86_64-linux/include/thrust/iterator/detail/iterator_facade_category.h:22,
                 from /opt/software/CUDA/11.5/targets/x86_64-linux/include/thrust/iterator/iterator_facade.h:37,
                 from /home/user/parflow/pfsimulator/parflow_lib/../third_party/cub/device/../iterator/arg_index_input_iterator.cuh:48,
                 from /home/user/parflow/pfsimulator/parflow_lib/../third_party/cub/device/device_reduce.cuh:41,
                 from /home/user/parflow/pfsimulator/parflow_lib/../third_party/cub/cub.cuh:53,
                 from /home/user/parflow/pfsimulator/parflow_lib/pf_cudaloops.h:36,
                 from /home/user/parflow/pfsimulator/parflow_lib/backend_mapping.h:61,
                 from /home/user/parflow/pfsimulator/parflow_lib/parflow.h:80,
                 from /home/user/parflow/pfsimulator/parflow_lib/axpy.c:32,
                 from /home/user/parflow/pfsimulator/parflow_lib/axpy.cpp:22:
/opt/software/CUDA/11.5/targets/x86_64-linux/include/cub/util_namespace.cuh:46:2: error: #error CUB requires a definition of CUB_NS_QUALIFIER when CUB_NS_PREFIX/POSTFIX are defined.
   46 | #error CUB requires a definition of CUB_NS_QUALIFIER when CUB_NS_PREFIX/POSTFIX are defined.
      |  ^~~~~
```

This error is documented in [CUB 1.14 release notes](https://github.com/NVIDIA/cub/releases/tag/1.14.0#Breaking-Changes). Fix is to add the `CUB_NS_QUALIFIER` macro in the same way it was added in the CUB (see https://github.com/NVIDIA/cub/blob/94a50bf20cc01f44863a524ba36e089fd80f342e/cub/util_namespace.cuh#L99-L109)