### PR TITLE
Python PFTools, read subgrid info from file

### DIFF
--- a/pftools/python/parflow/tools/io.py
+++ b/pftools/python/parflow/tools/io.py
@@ -56,7 +56,7 @@ except ImportError:
 
 
 def read_pfb(file: str, keys: dict=None, mode: str='full', z_first: bool=True,
-             read_sg_info: bool=False):
+             read_sg_info: bool=True):
     """
     Read a single pfb file, and return the data therein
 

--- a/pftools/python/parflow/tools/io.py
+++ b/pftools/python/parflow/tools/io.py
@@ -56,7 +56,7 @@ except ImportError:
 
 
 def read_pfb(file: str, keys: dict=None, mode: str='full', z_first: bool=True,
-             read_sginfo: bool=False):
+             read_sg_info: bool=False):
     """
     Read a single pfb file, and return the data therein
 
@@ -75,14 +75,14 @@ def read_pfb(file: str, keys: dict=None, mode: str='full', z_first: bool=True,
     :param mode:
         The mode for the reader. See ``ParflowBinaryReader::read_all_subgrids``
         for more information about what modes are available.
-    :param read_sginfo:
+    :param read_sg_info:
         Precalculating subgrid information does not always work correctly for
         some files, especially velocity files. If ``True``, read subgrid info 
         directly from the pfb file (slower, but more robust)
     :return:
         An nd array containing the data from the pfb file.
     """
-    with ParflowBinaryReader(file, read_sginfo_fromfile=read_sginfo) as pfb:
+    with ParflowBinaryReader(file, read_sg_info=read_sg_info) as pfb:
         if not keys:
             data = pfb.read_all_subgrids(mode=mode, z_first=z_first)
         else:
@@ -244,7 +244,7 @@ def read_pfb_sequence(
     keys=None,
     z_first: bool=True,
     z_is: str='z',
-    read_sginfo: bool=False
+    read_sg_info: bool=False
 ):
     """
     An efficient wrapper to read a sequence of pfb files. This
@@ -270,7 +270,7 @@ def read_pfb_sequence(
     :param z_is:
         A descriptor of what the z axis represents. Can be one of
         'z', 'time', 'variable'. Default is 'z'.
-    :param read_sginfo:
+    :param read_sg_info:
         Precalculating subgrid information does not always work correctly for
         some files, especially velocity files. If ``True``, read subgrid info 
         directly from the pfb file (slower, but more robust)
@@ -280,7 +280,7 @@ def read_pfb_sequence(
     """
     # Filter out unique files only
     file_seq = sorted(list(set(file_seq)))
-    with ParflowBinaryReader(file_seq[0], read_sginfo_fromfile=read_sginfo) as pfb_init:
+    with ParflowBinaryReader(file_seq[0], read_sg_info=read_sg_info) as pfb_init:
         base_header = pfb_init.header
         base_sg_offsets = pfb_init.subgrid_offsets
         base_sg_locations = pfb_init.subgrid_locations
@@ -369,7 +369,7 @@ class ParflowBinaryReader:
     :param header:
         A dictionary representing the header of the pfb file. This is an optional
         input, if it is not given we will read it from the pfb file directly.
-    :param read_sginfo_fromfile:
+    :param read_sg_info:
         Whether or not to read subgrid information directly from the pfb file.
         Precalculating subgrid information does not always work correctly for
         some files, especially velocity files. This reads the subgrid offset 
@@ -386,7 +386,7 @@ class ParflowBinaryReader:
         q: int=None,
         r: int=None,
         header: Mapping[str, Number]=None,
-        read_sginfo_fromfile: bool=False
+        read_sg_info: bool=False
     ):
         self.filename = file
         self.f = open(self.filename, 'rb')
@@ -414,7 +414,7 @@ class ParflowBinaryReader:
         if precompute_subgrid_info:
             self.compute_subgrid_info()
 
-        if read_sginfo_fromfile:
+        if read_sg_info:
             self.read_subgrid_info()
             
     def close(self):

--- a/pftools/python/parflow/tools/io.py
+++ b/pftools/python/parflow/tools/io.py
@@ -55,7 +55,8 @@ except ImportError:
     from yaml import Dumper as YAMLDumper
 
 
-def read_pfb(file: str, keys: dict=None, mode: str='full', z_first: bool=True):
+def read_pfb(file: str, keys: dict=None, mode: str='full', z_first: bool=True,
+             read_sginfo: bool=False):
     """
     Read a single pfb file, and return the data therein
 
@@ -74,10 +75,14 @@ def read_pfb(file: str, keys: dict=None, mode: str='full', z_first: bool=True):
     :param mode:
         The mode for the reader. See ``ParflowBinaryReader::read_all_subgrids``
         for more information about what modes are available.
+    :param read_sginfo:
+        Precalculating subgrid information does not always work correctly for
+        some files, especially velocity files. If ``True``, read subgrid info 
+        directly from the pfb file (slower, but more robust)
     :return:
         An nd array containing the data from the pfb file.
     """
-    with ParflowBinaryReader(file) as pfb:
+    with ParflowBinaryReader(file, read_sginfo_fromfile=read_sginfo) as pfb:
         if not keys:
             data = pfb.read_all_subgrids(mode=mode, z_first=z_first)
         else:
@@ -238,7 +243,8 @@ def read_pfb_sequence(
     file_seq: Iterable[str],
     keys=None,
     z_first: bool=True,
-    z_is: str='z'
+    z_is: str='z',
+    read_sginfo: bool=False
 ):
     """
     An efficient wrapper to read a sequence of pfb files. This
@@ -264,13 +270,17 @@ def read_pfb_sequence(
     :param z_is:
         A descriptor of what the z axis represents. Can be one of
         'z', 'time', 'variable'. Default is 'z'.
-
+    :param read_sginfo:
+        Precalculating subgrid information does not always work correctly for
+        some files, especially velocity files. If ``True``, read subgrid info 
+        directly from the pfb file (slower, but more robust)
+    
     :return:
         An nd array containing the data from the files.
     """
     # Filter out unique files only
     file_seq = sorted(list(set(file_seq)))
-    with ParflowBinaryReader(file_seq[0]) as pfb_init:
+    with ParflowBinaryReader(file_seq[0], read_sginfo_fromfile=read_sginfo) as pfb_init:
         base_header = pfb_init.header
         base_sg_offsets = pfb_init.subgrid_offsets
         base_sg_locations = pfb_init.subgrid_locations
@@ -359,6 +369,13 @@ class ParflowBinaryReader:
     :param header:
         A dictionary representing the header of the pfb file. This is an optional
         input, if it is not given we will read it from the pfb file directly.
+    :param read_sginfo_fromfile:
+        Whether or not to read subgrid information directly from the pfb file.
+        Precalculating subgrid information does not always work correctly for
+        some files, especially velocity files. This reads the subgrid offset 
+        bytes, subgrid indices and subgrid shapes, then computes the subgrid 
+        coordinates subgrid locations, and chunk sizes as normal
+        
     """
 
     def __init__(
@@ -368,7 +385,8 @@ class ParflowBinaryReader:
         p: int=None,
         q: int=None,
         r: int=None,
-        header: Mapping[str, Number]=None
+        header: Mapping[str, Number]=None,
+        read_sginfo_fromfile: bool=False
     ):
         self.filename = file
         self.f = open(self.filename, 'rb')
@@ -396,6 +414,9 @@ class ParflowBinaryReader:
         if precompute_subgrid_info:
             self.compute_subgrid_info()
 
+        if read_sginfo_fromfile:
+            self.read_subgrid_info()
+            
     def close(self):
         self.f.close()
 
@@ -418,6 +439,41 @@ class ParflowBinaryReader:
             )
         except:
             raise ValueError(self.header)
+        self.subgrid_offsets = np.array(sg_offs)
+        self.subgrid_locations = np.array(sg_locs)
+        self.subgrid_start_indices = np.array(sg_starts)
+        self.subgrid_shapes = np.array(sg_shapes)
+        self.chunks = self._compute_chunks()
+        self.coords = self._compute_coords()
+
+    def read_subgrid_info(self):
+        """ Read the header for each subgrid directly from the pfb file, rather 
+        than calculating it via precalculate_subgrid_info """
+        
+        sg_shapes = []
+        sg_offs = []
+        sg_locs = []
+        sg_starts = []
+
+        off = 64
+        for sg_num in range(self.header['n_subgrids']):
+            # Read and move past the current subgrid header
+            sg_head = self.read_subgrid_header(off)
+            off += 36 
+            
+            sg_starts.append([sg_head['ix'], sg_head['iy'], sg_head['iz']])
+            sg_shapes.append([sg_head['nx'], sg_head['ny'], sg_head['nz']])
+            sg_offs.append(off)
+
+            # Calculate subgrid locs instead of reading from file
+            sg_p, sg_q, sg_r = get_subgrid_loc(sg_num, self.header['p'], 
+                                                       self.header['q'], 
+                                                       self.header['r'])
+            sg_locs.append((sg_p, sg_q, sg_r))
+            
+            # Finally, move past the current subgrid before next iteration
+            off += sg_head['sg_size']*8
+        
         self.subgrid_offsets = np.array(sg_offs)
         self.subgrid_locations = np.array(sg_locs)
         self.subgrid_start_indices = np.array(sg_starts)


### PR DESCRIPTION
This addresses https://github.com/parflow/parflow/issues/402 

It adds the `read_subgrid_info` method to the `ParflowBinaryReader` class, which directly reads the subgrid header from file, rather than calculating that info using _nx_, _ny_, _nz_, _p_, _q_ and _r_. This is useful when reading velocity files. For example, since velx files report values at cell faces in the _x_ direction, if _p_ > 1 in the process topology, each subgrid includes one extra row/column in the _x_ direction. 

To fix the use case in https://github.com/parflow/parflow/issues/402, use `read_sginfo=True` when reading velocity files:

```python
from parflow import read_pfb

velx = read_pfb('default_richards.out.velx.00001.pfb',
                read_sginfo=True)
print(velx.min(), velx.max())
```

