### PR TITLE
DRAFT: Fix bug in calcluating subgrid numbers when not provided to reader

### DIFF
--- a/pftools/python/parflow/tools/io.py
+++ b/pftools/python/parflow/tools/io.py
@@ -382,6 +382,7 @@ class ParflowBinaryReader:
             self.header['q'] = q
             self.header['r'] = r
 
+        nx, ny, nz = self.header['nx'], self.header['ny'], self.header['nz']
         if not ('p' in self.header
             and 'q' in self.header
             and 'r' in self.header):
@@ -389,9 +390,17 @@ class ParflowBinaryReader:
             # NOTE: This is a bit of a fallback and may not always work
             eps = 1 - 1e-6
             first_sg_head = self.read_subgrid_header()
-            self.header['p'] = int((self.header['nx'] / first_sg_head['nx']) + eps)
-            self.header['q'] = int((self.header['ny'] / first_sg_head['ny']) + eps)
-            self.header['r'] = int((self.header['nz'] / first_sg_head['nz']) + eps)
+            ptest = int(( nx / first_sg_head['nx']) + eps)
+            qtest = int(( ny / first_sg_head['ny']) + eps)
+            rtest = int(( nz / first_sg_head['nz']) + eps)
+            # Check if adding 1 to the number of subgrids would reduce
+            # the remainder. If so, add one to the subgrids along that dimension.
+            if (nx % ptest) > (nx % (ptest+1)): ptest += 1
+            if (ny % qtest) > (ny % (qtest+1)): qtest += 1
+            if (nz % rtest) > (nz % (qtest+1)): rtest += 1
+            self.header['p'] = ptest
+            self.header['q'] = qtest
+            self.header['r'] = rtest
 
         if precompute_subgrid_info:
             self.compute_subgrid_info()


### PR DESCRIPTION
There was an off-by-one error that could occur when calculating the p,q,r values from the header and first subgrid header. This is fixed by checking if adding 1 to the number of subgrids in any of the dimensions would reduce the remainder.

Update: This should not yet be merged, I think I have found a secondary corner case where this causes new failures.