### PR TITLE
Error in Eq. 4.35 - Subsurface storage

### DIFF
--- a/docs/user_manual/models.rst
+++ b/docs/user_manual/models.rst
@@ -750,8 +750,8 @@ being an array of balances over the domain) as follows:
    :label: sub_store
 
    \begin{aligned}
-   Vol_{subsurface} = \sum_\Omega [ S(\psi)S_s \psi \Delta x \Delta y \Delta z +
-   S(\psi)(\psi)\phi \Delta x \Delta y \Delta z]
+   Vol_{subsurface} = \sum_\Omega [ S(\psi) S_s \psi \Delta x \Delta y \Delta z +
+   S(\psi) \phi \Delta x \Delta y \Delta z]
    \end{aligned} 
 
 The surface storage is calculated over the upper surface boundary 


### PR DESCRIPTION
Based on the [PFtools water balance formulation](https://github.com/parflow/parflow/blob/master/pftools/water_balance.c), it seems that (\psi) is repeated in the second half of Eq. 4.35. Also notice that ∆𝑥, ∆𝑦, and ∆z are not defined in Section 4 (MODEL EQUATIONS).