### PR TITLE
Netcdf clean

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -250,7 +250,7 @@ jobs:
           wget -q https://github.com/Unidata/netcdf-fortran/archive/v4.5.0.tar.gz
           tar -xf v4.5.0.tar.gz
           cd netcdf-fortran-4.5.0
-          CC=mpicc FC=mpifort CPPFLAGS=-I${PARFLOW_DEP_DIR}/include LDFLAGS=-L${PARFLOW_DEP_DIR}/lib ./configure --disable-shared --prefix=${PARFLOW_DEP_DIR}
+          CC=mpicc FC=mpifort CPPFLAGS=-I${PARFLOW_DEP_DIR}/include LDFLAGS=-L${PARFLOW_DEP_DIR}/lib LIBS="-lhdf5_hl -lhdf5 -lcurl" ./configure --disable-shared --prefix=${PARFLOW_DEP_DIR}
           make
           make install
           cd ..

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -242,7 +242,7 @@ jobs:
           wget -q https://github.com/Unidata/netcdf-c/archive/v4.5.0.tar.gz
           tar -xf v4.5.0.tar.gz
           cd netcdf-c-4.5.0
-          CC=mpicc CPPFLAGS=-I/usr/include/hdf5/openmpi LDFLAGS=-L/usr/lib/x86_64-linux-gnu/hdf5/openmpi ./configure --prefix=$PARFLOW_DEP_DIR
+          CC=mpicc CPPFLAGS=-I/usr/include/hdf5/openmpi LDFLAGS=-L/usr/lib/x86_64-linux-gnu/hdf5/openmpi ./configure --disabled-shared --prefix=$PARFLOW_DEP_DIR
           make
           make install
           cd ..
@@ -250,7 +250,7 @@ jobs:
           wget -q https://github.com/Unidata/netcdf-fortran/archive/v4.5.0.tar.gz
           tar -xf v4.5.0.tar.gz
           cd netcdf-fortran-4.5.0
-          CC=mpicc FC=mpifort CPPFLAGS=-I${PARFLOW_DEP_DIR}/include LDFLAGS=-L${PARFLOW_DEP_DIR}/lib ./configure --prefix=${PARFLOW_DEP_DIR}
+          CC=mpicc FC=mpifort CPPFLAGS=-I${PARFLOW_DEP_DIR}/include LDFLAGS=-L${PARFLOW_DEP_DIR}/lib ./configure --disabled-shared --prefix=${PARFLOW_DEP_DIR}
           make
           make install
           cd ..

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -250,7 +250,7 @@ jobs:
           wget -q https://github.com/Unidata/netcdf-fortran/archive/v4.5.0.tar.gz
           tar -xf v4.5.0.tar.gz
           cd netcdf-fortran-4.5.0
-          CC=mpicc FC=mpifort CPPFLAGS=-I${PARFLOW_DIR}/include LDFLAGS=-L${PARFLOW_DIR}/lib ./configure --prefix=${PARFLOW_DIR}
+          CC=mpicc FC=mpifort CPPFLAGS=-I${PARFLOW_DEP_DIR}/include LDFLAGS=-L${PARFLOW_DEP_DIR}/lib ./configure --prefix=${PARFLOW_DEP_DIR}
           make
           make install
           cd ..

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -245,8 +245,8 @@ jobs:
           CC=mpicc CPPFLAGS=-I/usr/include/hdf5/openmpi LDFLAGS=-L/usr/lib/x86_64-linux-gnu/hdf5/openmpi ./configure --prefix=$PARFLOW_DEP_DIR
           make
           make install
-          rm v4.5.0.tar.gz
           cd ..
+          rm v4.5.0.tar.gz
           wget -q https://github.com/Unidata/netcdf-fortran/archive/v4.5.0.tar.gz
           tar -xf v4.5.0.tar.gz
           cd netcdf-fortran-4.5.0

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -242,7 +242,7 @@ jobs:
           wget -q https://github.com/Unidata/netcdf-c/archive/v4.5.0.tar.gz
           tar -xf v4.5.0.tar.gz
           cd netcdf-c-4.5.0
-          CC=mpicc CPPFLAGS=-I/usr/include/hdf5/openmpi LDFLAGS=-L/usr/lib/x86_64-linux-gnu/hdf5/openmpi ./configure --disabled-shared --prefix=$PARFLOW_DEP_DIR
+          CC=mpicc CPPFLAGS=-I/usr/include/hdf5/openmpi LDFLAGS=-L/usr/lib/x86_64-linux-gnu/hdf5/openmpi ./configure --disable-shared --prefix=$PARFLOW_DEP_DIR
           make
           make install
           cd ..
@@ -250,7 +250,7 @@ jobs:
           wget -q https://github.com/Unidata/netcdf-fortran/archive/v4.5.0.tar.gz
           tar -xf v4.5.0.tar.gz
           cd netcdf-fortran-4.5.0
-          CC=mpicc FC=mpifort CPPFLAGS=-I${PARFLOW_DEP_DIR}/include LDFLAGS=-L${PARFLOW_DEP_DIR}/lib ./configure --disabled-shared --prefix=${PARFLOW_DEP_DIR}
+          CC=mpicc FC=mpifort CPPFLAGS=-I${PARFLOW_DEP_DIR}/include LDFLAGS=-L${PARFLOW_DEP_DIR}/lib ./configure --disable-shared --prefix=${PARFLOW_DEP_DIR}
           make
           make install
           cd ..

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -251,7 +251,7 @@ jobs:
           tar -xf v4.5.0.tar.gz
           cd netcdf-fortran-4.5.0
           CC=mpicc FC=mpifort CPPFLAGS=-I${PARFLOW_DEP_DIR}/include LDFLAGS=-L${PARFLOW_DEP_DIR}/lib LIBS="-lhdf5_hl -lhdf5 -lcurl" ./configure --disable-shared --prefix=${PARFLOW_DEP_DIR}
-	  cat config.log
+          cat config.log
           make
           make install
           cd ..

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -275,6 +275,7 @@ jobs:
           mv -v ${OASIS_ROOT}/install/include/* ${PARFLOW_DEP_DIR}/include/
           mv -v ${OASIS_ROOT}/install/lib/* ${PARFLOW_DEP_DIR}/lib/
         fi
+        echo "NETCDF_FLAGS=-DNETCDF_Fortran_ROOT=$PARFLOW_DEP_DIR" >> $GITHUB_ENV
 
     - name: SILO Install
       env:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -251,6 +251,7 @@ jobs:
           tar -xf v4.5.0.tar.gz
           cd netcdf-fortran-4.5.0
           CC=mpicc FC=mpifort CPPFLAGS=-I${PARFLOW_DEP_DIR}/include LDFLAGS=-L${PARFLOW_DEP_DIR}/lib LIBS="-lhdf5_hl -lhdf5 -lcurl" ./configure --disable-shared --prefix=${PARFLOW_DEP_DIR}
+	  cat config.log
           make
           make install
           cd ..

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -26,7 +26,7 @@ jobs:
             python: "false",
             backend: "omp",
             amps_layer: oas3,
-            netcdf: "false"
+            netcdf: "true"
           }
         - {
             name: "Ubuntu 18.04",
@@ -242,9 +242,17 @@ jobs:
           wget -q https://github.com/Unidata/netcdf-c/archive/v4.5.0.tar.gz
           tar -xf v4.5.0.tar.gz
           cd netcdf-c-4.5.0
-          CC=mpicc CPPFLAGS=-I/usr/include/hdf5/openmpi LDFLAGS=-L/usr/lib/x86_64-linux-gnu/hdf5/openmpi ./configure --disable-shared --prefix=$PARFLOW_DEP_DIR
+          CC=mpicc CPPFLAGS=-I/usr/include/hdf5/openmpi LDFLAGS=-L/usr/lib/x86_64-linux-gnu/hdf5/openmpi ./configure --prefix=$PARFLOW_DEP_DIR
           make
           make install
+          cd ..
+           wget -q https://github.com/Unidata/netcdf-fortran/archive/v4.5.0.tar.gz
+           tar -xf v4.5.0.tar.gz
+           cd netcdf-fortran-4.5.0
+           CC=mpicc FC=mpifort CPPFLAGS=-I${PARFLOW_DIR}/include LDFLAGS=-L${PARFLOW_DIR}/lib ./configure --prefix=${PARFLOW_DIR}
+           make
+           make install
+           cd ..
         fi
         echo "NETCDF_FLAGS=-DNETCDF_DIR=$PARFLOW_DEP_DIR -DPARFLOW_ENABLE_HDF5=TRUE" >> $GITHUB_ENV
 

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -242,20 +242,20 @@ jobs:
           wget -q https://github.com/Unidata/netcdf-c/archive/v4.5.0.tar.gz
           tar -xf v4.5.0.tar.gz
           cd netcdf-c-4.5.0
-          CC=mpicc CPPFLAGS=-I/usr/include/hdf5/openmpi LDFLAGS=-L/usr/lib/x86_64-linux-gnu/hdf5/openmpi ./configure --disable-shared --prefix=$PARFLOW_DEP_DIR
+          CC=mpicc CPPFLAGS=-I/usr/include/hdf5/openmpi LDFLAGS=-L/usr/lib/x86_64-linux-gnu/hdf5/openmpi ./configure --prefix=$PARFLOW_DEP_DIR
           make
           make install
           cd ..
           rm v4.5.0.tar.gz
-          wget -q https://github.com/Unidata/netcdf-fortran/archive/v4.5.0.tar.gz
-          tar -xf v4.5.0.tar.gz
-          cd netcdf-fortran-4.5.0
-          CC=mpicc FC=mpifort CPPFLAGS=-I${PARFLOW_DEP_DIR}/include LDFLAGS=-L${PARFLOW_DEP_DIR}/lib LIBS="-lhdf5_hl -lhdf5 -lcurl" ./configure --disable-shared --prefix=${PARFLOW_DEP_DIR}
+          wget -q https://github.com/Unidata/netcdf-fortran/archive/v4.4.4.tar.gz
+          tar -xf v4.4.4.tar.gz
+          cd netcdf-fortran-4.4.4
+          CC=mpicc FC=mpifort CPPFLAGS=-I${PARFLOW_DEP_DIR}/include LDFLAGS=-L${PARFLOW_DEP_DIR}/lib LIBS="-lhdf5_hl -lhdf5 -lcurl" ./configure --prefix=${PARFLOW_DEP_DIR}
           cat config.log
           make
           make install
           cd ..
-          rm v4.5.0.tar.gz
+          rm v4.4.4.tar.gz
         fi
         echo "NETCDF_FLAGS=-DNETCDF_DIR=$PARFLOW_DEP_DIR -DPARFLOW_ENABLE_HDF5=TRUE" >> $GITHUB_ENV
 
@@ -276,7 +276,6 @@ jobs:
           mv -v ${OASIS_ROOT}/install/include/* ${PARFLOW_DEP_DIR}/include/
           mv -v ${OASIS_ROOT}/install/lib/* ${PARFLOW_DEP_DIR}/lib/
         fi
-        echo "NETCDF_FLAGS=-DNETCDF_DIR=$PARFLOW_DEP_DIR -DNETCDF_Fortran_ROOT=$PARFLOW_DEP_DIR -DPARFLOW_ENABLE_HDF5=TRUE" >> $GITHUB_ENV
 
     - name: SILO Install
       env:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -250,8 +250,7 @@ jobs:
           wget -q https://github.com/Unidata/netcdf-fortran/archive/v4.4.4.tar.gz
           tar -xf v4.4.4.tar.gz
           cd netcdf-fortran-4.4.4
-          CC=mpicc FC=mpifort CPPFLAGS=-I${PARFLOW_DEP_DIR}/include LDFLAGS=-L${PARFLOW_DEP_DIR}/lib LIBS="-lhdf5_hl -lhdf5 -lcurl" ./configure --prefix=${PARFLOW_DEP_DIR}
-          cat config.log
+          CC=mpicc FC=mpifort CPPFLAGS=-I${PARFLOW_DEP_DIR}/include LDFLAGS=-L${PARFLOW_DEP_DIR}/lib ./configure --prefix=${PARFLOW_DEP_DIR}
           make
           make install
           cd ..

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -245,14 +245,16 @@ jobs:
           CC=mpicc CPPFLAGS=-I/usr/include/hdf5/openmpi LDFLAGS=-L/usr/lib/x86_64-linux-gnu/hdf5/openmpi ./configure --prefix=$PARFLOW_DEP_DIR
           make
           make install
+          rm v4.5.0.tar.gz
           cd ..
-           wget -q https://github.com/Unidata/netcdf-fortran/archive/v4.5.0.tar.gz
-           tar -xf v4.5.0.tar.gz
-           cd netcdf-fortran-4.5.0
-           CC=mpicc FC=mpifort CPPFLAGS=-I${PARFLOW_DIR}/include LDFLAGS=-L${PARFLOW_DIR}/lib ./configure --prefix=${PARFLOW_DIR}
-           make
-           make install
-           cd ..
+          wget -q https://github.com/Unidata/netcdf-fortran/archive/v4.5.0.tar.gz
+          tar -xf v4.5.0.tar.gz
+          cd netcdf-fortran-4.5.0
+          CC=mpicc FC=mpifort CPPFLAGS=-I${PARFLOW_DIR}/include LDFLAGS=-L${PARFLOW_DIR}/lib ./configure --prefix=${PARFLOW_DIR}
+          make
+          make install
+          cd ..
+          rm v4.5.0.tar.gz
         fi
         echo "NETCDF_FLAGS=-DNETCDF_DIR=$PARFLOW_DEP_DIR -DPARFLOW_ENABLE_HDF5=TRUE" >> $GITHUB_ENV
 

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -263,8 +263,6 @@ jobs:
         CACHE_HIT: ${{steps.cache-parflow-dependencies.outputs.cache-hit}}
       if: matrix.config.amps_layer == 'oas3'
       run: |
-        # OASIS can use package netcdf for building
-        sudo apt install -qq libnetcdf-dev libnetcdff-dev
         if [[ "$CACHE_HIT" != 'true' ]]; then
           git clone -b OASIS3-MCT_5.0 https://gitlab.com/cerfacs/oasis3-mct.git
           cd oasis3-mct
@@ -277,6 +275,7 @@ jobs:
           mv -v ${OASIS_ROOT}/install/include/* ${PARFLOW_DEP_DIR}/include/
           mv -v ${OASIS_ROOT}/install/lib/* ${PARFLOW_DEP_DIR}/lib/
         fi
+        echo "NETCDF_FLAGS=-DNETCDF_DIR=$PARFLOW_DEP_DIR -DNETCDF_Fortran_ROOT=$PARFLOW_DEP_DIR -DPARFLOW_ENABLE_HDF5=TRUE" >> $GITHUB_ENV
 
     - name: SILO Install
       env:
@@ -307,13 +306,9 @@ jobs:
     - name: ParFlow CMake Configure
       run: |
         cat ~/depend/cache-key
-        printenv PATH
-        which mpicc
-        which cmake
         export OMPI_MCA_rmaps_base_oversubscribe=1
         export OMP_NUM_THREADS=1
         if [[ "${{ matrix.config.amps_layer }}" == "oas3" ]]; then HAVE_CLM="OFF"; else HAVE_CLM="ON"; fi
-        echo "HAVE_CLM=${HAVE_CLM}"
         CC=mpicc CXX=mpicxx F77=mpif77 FC=mpif90 cmake -Bbuild -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_FLAGS="-Wall -Werror -Wno-unused-result -Wno-unused-function" -DPARFLOW_ENABLE_TIMING=TRUE -DPARFLOW_AMPS_LAYER=${{ matrix.config.amps_layer }} -DMPIEXEC_POSTFLAGS='--oversubscribe' -DPARFLOW_ACCELERATOR_BACKEND=${{ matrix.config.backend }} -DPARFLOW_AMPS_SEQUENTIAL_IO=true -DPARFLOW_HAVE_CLM=${HAVE_CLM} -DHYPRE_ROOT=$PARFLOW_DEP_DIR -DOAS3_ROOT=$PARFLOW_DEP_DIR -DSILO_ROOT=$PARFLOW_DEP_DIR -DPARFLOW_ENABLE_PYTHON=${{ matrix.config.python }} -DPARFLOW_PYTHON_VIRTUAL_ENV=${{ matrix.config.python }} $NETCDF_FLAGS $KOKKOS_FLAGS $RMM_FLAGS -DCMAKE_INSTALL_PREFIX=$PARFLOW_DIR
 
     - name: ParFlow CMake Build

--- a/misc/build_scripts/build.oasis3.ubuntu20.04
+++ b/misc/build_scripts/build.oasis3.ubuntu20.04
@@ -26,10 +26,10 @@ MPI_INCLUDE = $(MPIDIR)/include
 MPILIB      = -L$(MPIDIR)/lib -lmpi
 #
 # NETCDF library of the system
-NETCDF_INCLUDE1 = /usr/include
+NETCDF_INCLUDE1 = ${PARFLOW_DEP_DIR}/include
 # netcdf.mod and hdf5.mod
-NETCDF_INCLUDE2 = /usr/include/hdf5/openmpi
-NETCDF_LIBRARY  =  -L/usr/lib/x86_64-linux-gnu -lnetcdff -lnetcdf
+NETCDF_INCLUDE2 = ${PARFLOW_DEP_DIR}/include
+NETCDF_LIBRARY  =  -L/${PARLFLOW_DEP_DIR}/lib -lnetcdff -lnetcdf
 #
 # Compiling and other commands
 MAKE        = make


### PR DESCRIPTION
Unify NetCDF usage, the apt package NetCDF is not built with options needed by the PF writer.   Use a consistent NetCDF build for PF writer and OASIS3 builds to avoid conflicts.