### PR TITLE
Specify that slopex and slopey files are expected to be 2D pfbs

### DIFF
--- a/docs/user_manual/keys.rst
+++ b/docs/user_manual/keys.rst
@@ -2085,7 +2085,7 @@ specifies the value assigned to all points in the named geometry,
       <runname>.ToposlopeX.Geom.domain.Value = 0.001     ## Python syntax
 
 *double* **ToposlopesX.FileName** no default This key specifies the
-value assigned to all points be read in from a ParFlow binary file.
+value assigned to all points be read in from a ParFlow 2D binary file.
 
 .. container:: list
 
@@ -2096,7 +2096,7 @@ value assigned to all points be read in from a ParFlow binary file.
       <runname>.TopoSlopesX.FileName = "lw.1km.slope_x.pfb"    ## Python syntax
 
 *double* **ToposlopesY.FileName** no default This key specifies the
-value assigned to all points be read in from a ParFlow binary file.
+value assigned to all points be read in from a ParFlow 2D binary file.
 
 .. container:: list
 


### PR DESCRIPTION
Something similar should be done for the remaining input files, so model users can easily understand if a 2D or 3D file is expected as input.