### PR TITLE
Update ci images

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -79,6 +79,12 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
+    - name: Package Install 22.04
+      if: matrix.config.os == 'ubuntu-22.04'
+      run: |
+        sudo apt-get -qq update
+        sudo apt -qq install gfortran libhdf5-openmpi-dev libhdf5-openmpi-103 hdf5-helpers tcl-dev tk-dev libcurl4 libcurl4-gnutls-dev
+
     - name: Package Install 20.04
       if: matrix.config.os == 'ubuntu-20.04'
       run: |
@@ -321,4 +327,3 @@ jobs:
         export OMPI_MCA_rmaps_base_oversubscribe=1
         export OMP_NUM_THREADS=1
         (cd build; ctest --output-on-failure)
-

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -315,6 +315,8 @@ jobs:
         cat ~/depend/cache-key
         export OMPI_MCA_rmaps_base_oversubscribe=1
         export OMP_NUM_THREADS=1
+	gcc -v
+	mpicc -v
         if [[ "${{ matrix.config.amps_layer }}" == "oas3" ]]; then HAVE_CLM="OFF"; else HAVE_CLM="ON"; fi
         CC=mpicc CXX=mpicxx F77=mpif77 FC=mpif90 cmake -Bbuild -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_FLAGS="-Wall -Werror -Wno-unused-result -Wno-unused-function" -DPARFLOW_ENABLE_TIMING=TRUE -DPARFLOW_AMPS_LAYER=${{ matrix.config.amps_layer }} -DMPIEXEC_POSTFLAGS='--oversubscribe' -DPARFLOW_ACCELERATOR_BACKEND=${{ matrix.config.backend }} -DPARFLOW_AMPS_SEQUENTIAL_IO=true -DPARFLOW_HAVE_CLM=${HAVE_CLM} -DHYPRE_ROOT=$PARFLOW_DEP_DIR -DOAS3_ROOT=$PARFLOW_DEP_DIR -DSILO_ROOT=$PARFLOW_DEP_DIR -DPARFLOW_ENABLE_PYTHON=${{ matrix.config.python }} -DPARFLOW_PYTHON_VIRTUAL_ENV=${{ matrix.config.python }} $NETCDF_FLAGS $KOKKOS_FLAGS $RMM_FLAGS -DCMAKE_INSTALL_PREFIX=$PARFLOW_DIR
 

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -95,8 +95,8 @@ jobs:
         sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 78BD65473CB3BD13
         sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 6B05F25D762E3157
 
-    - name: Package Install 20.04
-      if: matrix.config.os == 'ubuntu-20.04'
+    - name: Package Install 18.04
+      if: matrix.config.os == 'ubuntu-18.04'
       run: |
         sudo apt-get -qq update
         sudo apt -qq install gfortran libhdf5-openmpi-dev libhdf5-openmpi-100 hdf5-helpers tcl-dev tk-dev libcurl4 libcurl4-gnutls-dev

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -10,29 +10,20 @@ jobs:
       # fail-fast: true
       matrix:
         config:
-        # - {
-        #     name: "Ubuntu 22.04",
-        #     os: ubuntu-22.04,
-        #     cudaos: 'ubuntu2204',
-        #     python: "false",
-        #     backend: "none",
-        #     amps_layer: mpi1,
-        #     netcdf: "true"
-        #   }
         - {
-            name: "Ubuntu 20.04 OASIS3-MCT Build",
-            os: ubuntu-20.04,
-            cudaos: 'ubuntu2004',
+            name: "Ubuntu 22.04",
+            os: ubuntu-22.04,
+            cudaos: 'ubuntu2204',
             python: "false",
-            backend: "omp",
-            amps_layer: oas3,
+            backend: "none",
+            amps_layer: mpi1,
             netcdf: "true"
           }
         - {
-            name: "Ubuntu 20.04",
-            os: ubuntu-20.04,
-            cudaos: 'ubuntu2004',
-            python: "false",
+            name: "Ubuntu 22.04 Python",
+            os: ubuntu-22.04,
+            cudaos: 'ubuntu2204',
+            python: "true",
             backend: "none",
             amps_layer: mpi1,
             netcdf: "true"
@@ -47,34 +38,43 @@ jobs:
             netcdf: "false"
           }
         - {
-            name: "Ubuntu 20.04 OMP",
-            os: ubuntu-20.04,
-            cudaos: 'ubuntu2004',
+            name: "Ubuntu 22.04 OMP",
+            os: ubuntu-22.04,
+            cudaos: 'ubuntu2204',
             python: "false",
             backend: "omp",
             amps_layer: mpi1,
             netcdf: "false"
           }
-        - {
-            name: "Ubuntu 20.04 CUDA Build",
-            os: ubuntu-20.04,
-            cc: "gcc", cxx: "g++",
-            python: "false",
-            backend: "cuda",
-            cudaos: 'ubuntu2004',
-            amps_layer: mpi1,
-            netcdf: "false"
-          }
-        - {
-            name: "Ubuntu 20.04 Kokkos Build",
-            os: ubuntu-20.04,
-            cc: "gcc", cxx: "g++",
-            python: "false",
-            backend: "kokkos",
-            cudaos: 'ubuntu2004',
-            amps_layer: mpi1,
-            netcdf: "false"
-          }
+        # - {
+        #     name: "Ubuntu 18.04 OASIS3-MCT Build",
+        #     os: ubuntu-18.04,
+        #     cudaos: 'ubuntu1804',
+        #     python: "false",
+        #     backend: "omp",
+        #     amps_layer: oas3,
+        #     netcdf: "true"
+        #   }
+        # - {
+        #     name: "Ubuntu 18.04 CUDA Build",
+        #     os: ubuntu-18.04,
+        #     cc: "gcc", cxx: "g++",
+        #     python: "false",
+        #     backend: "cuda",
+        #     cudaos: 'ubuntu1804',
+        #     amps_layer: mpi1,
+        #     netcdf: "false"
+        #   }
+        # - {
+        #     name: "Ubuntu 18.04 Kokkos Build",
+        #     os: ubuntu-18.04,
+        #     cc: "gcc", cxx: "g++",
+        #     python: "false",
+        #     backend: "kokkos",
+        #     cudaos: 'ubuntu1804',
+        #     amps_layer: mpi1,
+        #     netcdf: "false"
+        #   }
 
     steps:
     - uses: actions/checkout@v2
@@ -85,8 +85,8 @@ jobs:
         sudo apt-get -qq update
         sudo apt -qq install gfortran libhdf5-openmpi-dev libhdf5-openmpi-103 hdf5-helpers tcl-dev tk-dev libcurl4 libcurl4-gnutls-dev
 
-    - name: Package Install 20.04 CUDA
-      if: (matrix.config.backend == 'cuda' || matrix.config.backend == 'kokkos') && matrix.config.os == 'ubuntu-20.04'
+    - name: Package Install 18.04 CUDA
+      if: (matrix.config.backend == 'cuda' || matrix.config.backend == 'kokkos') && matrix.config.os == 'ubuntu-18.04'
       run: |
         sudo apt-get -qq update
         sudo apt-get -qq install -y software-properties-common
@@ -239,22 +239,22 @@ jobs:
       if: matrix.config.netcdf == 'true'
       run: |
         if [[ "$CACHE_HIT" != 'true' ]]; then
-          wget -q https://github.com/Unidata/netcdf-c/archive/v4.5.0.tar.gz
-          tar -xf v4.5.0.tar.gz
-          cd netcdf-c-4.5.0
+          wget -q https://github.com/Unidata/netcdf-c/archive/v4.9.0.tar.gz
+          tar -xf v4.9.0.tar.gz
+          cd netcdf-c-4.9.0
           CC=mpicc CPPFLAGS=-I/usr/include/hdf5/openmpi LDFLAGS=-L/usr/lib/x86_64-linux-gnu/hdf5/openmpi ./configure --prefix=$PARFLOW_DEP_DIR
           make
           make install
           cd ..
-          rm v4.5.0.tar.gz
-          wget -q https://github.com/Unidata/netcdf-fortran/archive/v4.4.4.tar.gz
-          tar -xf v4.4.4.tar.gz
-          cd netcdf-fortran-4.4.4
+          rm v4.9.0.tar.gz
+          wget -q https://github.com/Unidata/netcdf-fortran/archive/v4.5.4.tar.gz
+          tar -xf v4.5.4.tar.gz
+          cd netcdf-fortran-4.5.4
           CC=mpicc FC=mpifort CPPFLAGS=-I${PARFLOW_DEP_DIR}/include LDFLAGS=-L${PARFLOW_DEP_DIR}/lib ./configure --prefix=${PARFLOW_DEP_DIR}
           make
           make install
           cd ..
-          rm v4.4.4.tar.gz
+          rm v4.5.4.tar.gz
         fi
         echo "NETCDF_FLAGS=-DNETCDF_DIR=$PARFLOW_DEP_DIR -DPARFLOW_ENABLE_HDF5=TRUE" >> $GITHUB_ENV
 

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -37,15 +37,15 @@ jobs:
             amps_layer: mpi1,
             netcdf: "true"
           }
-        # - {
-        #     name: "Ubuntu 20.04 Python",
-        #     os: ubuntu-20.04,
-        #     cudaos: 'ubuntu2004',
-        #     python: "true",
-        #     backend: "none",
-        #     amps_layer: mpi1,
-        #     netcdf: "false"
-        #   }
+        - {
+            name: "Ubuntu 20.04 Python",
+            os: ubuntu-20.04,
+            cudaos: 'ubuntu2004',
+            python: "true",
+            backend: "none",
+            amps_layer: mpi1,
+            netcdf: "false"
+          }
         # - {
         #     name: "Ubuntu 20.04 OMP",
         #     os: ubuntu-20.04,

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -318,7 +318,7 @@ jobs:
         gcc -v
         mpicc -v
         if [[ "${{ matrix.config.amps_layer }}" == "oas3" ]]; then HAVE_CLM="OFF"; else HAVE_CLM="ON"; fi
-        CC=mpicc CXX=mpicxx F77=mpif77 FC=mpif90 cmake -Bbuild -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_FLAGS="-Wall -Werror -Wno-unused-result -Wno-unused-function" -DPARFLOW_ENABLE_TIMING=TRUE -DPARFLOW_AMPS_LAYER=${{ matrix.config.amps_layer }} -DMPIEXEC_POSTFLAGS='--oversubscribe' -DPARFLOW_ACCELERATOR_BACKEND=${{ matrix.config.backend }} -DPARFLOW_AMPS_SEQUENTIAL_IO=true -DPARFLOW_HAVE_CLM=${HAVE_CLM} -DHYPRE_ROOT=$PARFLOW_DEP_DIR -DOAS3_ROOT=$PARFLOW_DEP_DIR -DSILO_ROOT=$PARFLOW_DEP_DIR -DPARFLOW_ENABLE_PYTHON=${{ matrix.config.python }} -DPARFLOW_PYTHON_VIRTUAL_ENV=${{ matrix.config.python }} $NETCDF_FLAGS $KOKKOS_FLAGS $RMM_FLAGS -DCMAKE_INSTALL_PREFIX=$PARFLOW_DIR
+        CC=mpicc CXX=mpicxx F77=mpif77 FC=mpif90 cmake -Bbuild -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_FLAGS="-Wall -Wno-unused-result -Wno-unused-function" -DPARFLOW_ENABLE_TIMING=TRUE -DPARFLOW_AMPS_LAYER=${{ matrix.config.amps_layer }} -DMPIEXEC_POSTFLAGS='--oversubscribe' -DPARFLOW_ACCELERATOR_BACKEND=${{ matrix.config.backend }} -DPARFLOW_AMPS_SEQUENTIAL_IO=true -DPARFLOW_HAVE_CLM=${HAVE_CLM} -DHYPRE_ROOT=$PARFLOW_DEP_DIR -DOAS3_ROOT=$PARFLOW_DEP_DIR -DSILO_ROOT=$PARFLOW_DEP_DIR -DPARFLOW_ENABLE_PYTHON=${{ matrix.config.python }} -DPARFLOW_PYTHON_VIRTUAL_ENV=${{ matrix.config.python }} $NETCDF_FLAGS $KOKKOS_FLAGS $RMM_FLAGS -DCMAKE_INSTALL_PREFIX=$PARFLOW_DIR
 
     - name: ParFlow CMake Build
       run: (cd build; make -j 2 install)

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -26,7 +26,7 @@ jobs:
             python: "false",
             backend: "omp",
             amps_layer: oas3,
-            netcdf: "false"
+            netcdf: "true"
           }
         - {
             name: "Ubuntu 18.04",
@@ -242,9 +242,19 @@ jobs:
           wget -q https://github.com/Unidata/netcdf-c/archive/v4.5.0.tar.gz
           tar -xf v4.5.0.tar.gz
           cd netcdf-c-4.5.0
-          CC=mpicc CPPFLAGS=-I/usr/include/hdf5/openmpi LDFLAGS=-L/usr/lib/x86_64-linux-gnu/hdf5/openmpi ./configure --disable-shared --prefix=$PARFLOW_DEP_DIR
+          CC=mpicc CPPFLAGS=-I/usr/include/hdf5/openmpi LDFLAGS=-L/usr/lib/x86_64-linux-gnu/hdf5/openmpi ./configure --prefix=$PARFLOW_DEP_DIR
           make
           make install
+          cd ..
+          rm v4.5.0.tar.gz
+          wget -q https://github.com/Unidata/netcdf-fortran/archive/v4.4.4.tar.gz
+          tar -xf v4.4.4.tar.gz
+          cd netcdf-fortran-4.4.4
+          CC=mpicc FC=mpifort CPPFLAGS=-I${PARFLOW_DEP_DIR}/include LDFLAGS=-L${PARFLOW_DEP_DIR}/lib ./configure --prefix=${PARFLOW_DEP_DIR}
+          make
+          make install
+          cd ..
+          rm v4.4.4.tar.gz
         fi
         echo "NETCDF_FLAGS=-DNETCDF_DIR=$PARFLOW_DEP_DIR -DPARFLOW_ENABLE_HDF5=TRUE" >> $GITHUB_ENV
 
@@ -253,8 +263,6 @@ jobs:
         CACHE_HIT: ${{steps.cache-parflow-dependencies.outputs.cache-hit}}
       if: matrix.config.amps_layer == 'oas3'
       run: |
-        # OASIS can use package netcdf for building
-        sudo apt install -qq libnetcdf-dev libnetcdff-dev
         if [[ "$CACHE_HIT" != 'true' ]]; then
           git clone -b OASIS3-MCT_5.0 https://gitlab.com/cerfacs/oasis3-mct.git
           cd oasis3-mct
@@ -267,6 +275,7 @@ jobs:
           mv -v ${OASIS_ROOT}/install/include/* ${PARFLOW_DEP_DIR}/include/
           mv -v ${OASIS_ROOT}/install/lib/* ${PARFLOW_DEP_DIR}/lib/
         fi
+        echo "NETCDF_FLAGS=-DNETCDF_Fortran_ROOT=$PARFLOW_DEP_DIR" >> $GITHUB_ENV
 
     - name: SILO Install
       env:
@@ -297,13 +306,9 @@ jobs:
     - name: ParFlow CMake Configure
       run: |
         cat ~/depend/cache-key
-        printenv PATH
-        which mpicc
-        which cmake
         export OMPI_MCA_rmaps_base_oversubscribe=1
         export OMP_NUM_THREADS=1
         if [[ "${{ matrix.config.amps_layer }}" == "oas3" ]]; then HAVE_CLM="OFF"; else HAVE_CLM="ON"; fi
-        echo "HAVE_CLM=${HAVE_CLM}"
         CC=mpicc CXX=mpicxx F77=mpif77 FC=mpif90 cmake -Bbuild -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_FLAGS="-Wall -Werror -Wno-unused-result -Wno-unused-function" -DPARFLOW_ENABLE_TIMING=TRUE -DPARFLOW_AMPS_LAYER=${{ matrix.config.amps_layer }} -DMPIEXEC_POSTFLAGS='--oversubscribe' -DPARFLOW_ACCELERATOR_BACKEND=${{ matrix.config.backend }} -DPARFLOW_AMPS_SEQUENTIAL_IO=true -DPARFLOW_HAVE_CLM=${HAVE_CLM} -DHYPRE_ROOT=$PARFLOW_DEP_DIR -DOAS3_ROOT=$PARFLOW_DEP_DIR -DSILO_ROOT=$PARFLOW_DEP_DIR -DPARFLOW_ENABLE_PYTHON=${{ matrix.config.python }} -DPARFLOW_PYTHON_VIRTUAL_ENV=${{ matrix.config.python }} $NETCDF_FLAGS $KOKKOS_FLAGS $RMM_FLAGS -DCMAKE_INSTALL_PREFIX=$PARFLOW_DIR
 
     - name: ParFlow CMake Build

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -2,7 +2,6 @@ name: ParFlow CI Test
 
 on: [push, pull_request]
 
-
 jobs:
   build:
     name: ${{ matrix.config.name }}

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -318,7 +318,7 @@ jobs:
         gcc -v
         mpicc -v
         if [[ "${{ matrix.config.amps_layer }}" == "oas3" ]]; then HAVE_CLM="OFF"; else HAVE_CLM="ON"; fi
-        CC=mpicc CXX=mpicxx F77=mpif77 FC=mpif90 cmake -Bbuild -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_FLAGS="-Wall -Wno-unused-result -Wno-unused-function" -DPARFLOW_ENABLE_TIMING=TRUE -DPARFLOW_AMPS_LAYER=${{ matrix.config.amps_layer }} -DMPIEXEC_POSTFLAGS='--oversubscribe' -DPARFLOW_ACCELERATOR_BACKEND=${{ matrix.config.backend }} -DPARFLOW_AMPS_SEQUENTIAL_IO=true -DPARFLOW_HAVE_CLM=${HAVE_CLM} -DHYPRE_ROOT=$PARFLOW_DEP_DIR -DOAS3_ROOT=$PARFLOW_DEP_DIR -DSILO_ROOT=$PARFLOW_DEP_DIR -DPARFLOW_ENABLE_PYTHON=${{ matrix.config.python }} -DPARFLOW_PYTHON_VIRTUAL_ENV=${{ matrix.config.python }} $NETCDF_FLAGS $KOKKOS_FLAGS $RMM_FLAGS -DCMAKE_INSTALL_PREFIX=$PARFLOW_DIR
+        CC=mpicc CXX=mpicxx F77=mpif77 FC=mpif90 cmake -Bbuild -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_FLAGS="-Wall -Werror -Wno-unused-result -Wno-unused-function" -DPARFLOW_ENABLE_TIMING=TRUE -DPARFLOW_AMPS_LAYER=${{ matrix.config.amps_layer }} -DMPIEXEC_POSTFLAGS='--oversubscribe' -DPARFLOW_ACCELERATOR_BACKEND=${{ matrix.config.backend }} -DPARFLOW_AMPS_SEQUENTIAL_IO=true -DPARFLOW_HAVE_CLM=${HAVE_CLM} -DHYPRE_ROOT=$PARFLOW_DEP_DIR -DOAS3_ROOT=$PARFLOW_DEP_DIR -DSILO_ROOT=$PARFLOW_DEP_DIR -DPARFLOW_ENABLE_PYTHON=${{ matrix.config.python }} -DPARFLOW_PYTHON_VIRTUAL_ENV=${{ matrix.config.python }} $NETCDF_FLAGS $KOKKOS_FLAGS $RMM_FLAGS -DCMAKE_INSTALL_PREFIX=$PARFLOW_DIR
 
     - name: ParFlow CMake Build
       run: (cd build; make -j 2 install)

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -47,35 +47,35 @@ jobs:
             amps_layer: mpi1,
             netcdf: "false"
           }
-        # - {
-        #     name: "Ubuntu 18.04 OASIS3-MCT Build",
-        #     os: ubuntu-18.04,
-        #     cudaos: 'ubuntu1804',
-        #     python: "false",
-        #     backend: "omp",
-        #     amps_layer: oas3,
-        #     netcdf: "true"
-        #   }
-        # - {
-        #     name: "Ubuntu 18.04 CUDA Build",
-        #     os: ubuntu-18.04,
-        #     cc: "gcc", cxx: "g++",
-        #     python: "false",
-        #     backend: "cuda",
-        #     cudaos: 'ubuntu1804',
-        #     amps_layer: mpi1,
-        #     netcdf: "false"
-        #   }
-        # - {
-        #     name: "Ubuntu 18.04 Kokkos Build",
-        #     os: ubuntu-18.04,
-        #     cc: "gcc", cxx: "g++",
-        #     python: "false",
-        #     backend: "kokkos",
-        #     cudaos: 'ubuntu1804',
-        #     amps_layer: mpi1,
-        #     netcdf: "false"
-        #   }
+        - {
+            name: "Ubuntu 18.04 OASIS3-MCT Build",
+            os: ubuntu-18.04,
+            cudaos: 'ubuntu1804',
+            python: "false",
+            backend: "omp",
+            amps_layer: oas3,
+            netcdf: "true"
+          }
+        - {
+            name: "Ubuntu 18.04 CUDA Build",
+            os: ubuntu-18.04,
+            cc: "gcc", cxx: "g++",
+            python: "false",
+            backend: "cuda",
+            cudaos: 'ubuntu1804',
+            amps_layer: mpi1,
+            netcdf: "false"
+          }
+        - {
+            name: "Ubuntu 18.04 Kokkos Build",
+            os: ubuntu-18.04,
+            cc: "gcc", cxx: "g++",
+            python: "false",
+            backend: "kokkos",
+            cudaos: 'ubuntu1804',
+            amps_layer: mpi1,
+            netcdf: "false"
+          }
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -315,8 +315,8 @@ jobs:
         cat ~/depend/cache-key
         export OMPI_MCA_rmaps_base_oversubscribe=1
         export OMP_NUM_THREADS=1
-	gcc -v
-	mpicc -v
+        gcc -v
+        mpicc -v
         if [[ "${{ matrix.config.amps_layer }}" == "oas3" ]]; then HAVE_CLM="OFF"; else HAVE_CLM="ON"; fi
         CC=mpicc CXX=mpicxx F77=mpif77 FC=mpif90 cmake -Bbuild -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_FLAGS="-Wall -Werror -Wno-unused-result -Wno-unused-function" -DPARFLOW_ENABLE_TIMING=TRUE -DPARFLOW_AMPS_LAYER=${{ matrix.config.amps_layer }} -DMPIEXEC_POSTFLAGS='--oversubscribe' -DPARFLOW_ACCELERATOR_BACKEND=${{ matrix.config.backend }} -DPARFLOW_AMPS_SEQUENTIAL_IO=true -DPARFLOW_HAVE_CLM=${HAVE_CLM} -DHYPRE_ROOT=$PARFLOW_DEP_DIR -DOAS3_ROOT=$PARFLOW_DEP_DIR -DSILO_ROOT=$PARFLOW_DEP_DIR -DPARFLOW_ENABLE_PYTHON=${{ matrix.config.python }} -DPARFLOW_PYTHON_VIRTUAL_ENV=${{ matrix.config.python }} $NETCDF_FLAGS $KOKKOS_FLAGS $RMM_FLAGS -DCMAKE_INSTALL_PREFIX=$PARFLOW_DIR
 

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -10,6 +10,24 @@ jobs:
       # fail-fast: true
       matrix:
         config:
+        # - {
+        #     name: "Ubuntu 22.04",
+        #     os: ubuntu-22.04,
+        #     cudaos: 'ubuntu2204',
+        #     python: "false",
+        #     backend: "none",
+        #     amps_layer: mpi1,
+        #     netcdf: "true"
+        #   }
+        # - {
+        #     name: "Ubuntu 20.04 OASIS3-MCT Build",
+        #     os: ubuntu-20.04,
+        #     cudaos: 'ubuntu2004',
+        #     python: "false",
+        #     backend: "omp",
+        #     amps_layer: oas3,
+        #     netcdf: "true"
+        #   }
         - {
             name: "Ubuntu 20.04",
             os: ubuntu-20.04,
@@ -19,62 +37,44 @@ jobs:
             amps_layer: mpi1,
             netcdf: "true"
           }
-        - {
-            name: "Ubuntu 20.04 OASIS3-MCT Build",
-            os: ubuntu-20.04,
-            cudaos: 'ubuntu2004',
-            python: "false",
-            backend: "omp",
-            amps_layer: oas3,
-            netcdf: "true"
-          }
-        - {
-            name: "Ubuntu 18.04",
-            os: ubuntu-18.04,
-            cudaos: 'ubuntu1804',
-            python: "false",
-            backend: "none",
-            amps_layer: mpi1,
-            netcdf: "false"
-          }
-        - {
-            name: "Ubuntu 18.04 Python",
-            os: ubuntu-18.04,
-            cudaos: 'ubuntu1804',
-            python: "true",
-            backend: "none",
-            amps_layer: mpi1,
-            netcdf: "false"
-          }
-        - {
-            name: "Ubuntu 18.04 OMP",
-            os: ubuntu-18.04,
-            cudaos: 'ubuntu1804',
-            python: "false",
-            backend: "omp",
-            amps_layer: mpi1,
-            netcdf: "false"
-          }
-        - {
-            name: "Ubuntu 18.04 CUDA Build",
-            os: ubuntu-18.04,
-            cc: "gcc", cxx: "g++",
-            python: "false",
-            backend: "cuda",
-            cudaos: 'ubuntu1804',
-            amps_layer: mpi1,
-            netcdf: "false"
-          }
-        - {
-            name: "Ubuntu 18.04 Kokkos Build",
-            os: ubuntu-18.04,
-            cc: "gcc", cxx: "g++",
-            python: "false",
-            backend: "kokkos",
-            cudaos: 'ubuntu1804',
-            amps_layer: mpi1,
-            netcdf: "false"
-          }
+        # - {
+        #     name: "Ubuntu 18.04 Python",
+        #     os: ubuntu-20.04,
+        #     cudaos: 'ubuntu2004',
+        #     python: "true",
+        #     backend: "none",
+        #     amps_layer: mpi1,
+        #     netcdf: "false"
+        #   }
+        # - {
+        #     name: "Ubuntu 18.04 OMP",
+        #     os: ubuntu-20.04,
+        #     cudaos: 'ubuntu2004',
+        #     python: "false",
+        #     backend: "omp",
+        #     amps_layer: mpi1,
+        #     netcdf: "false"
+        #   }
+        # - {
+        #     name: "Ubuntu 18.04 CUDA Build",
+        #     os: ubuntu-20.04,
+        #     cc: "gcc", cxx: "g++",
+        #     python: "false",
+        #     backend: "cuda",
+        #     cudaos: 'ubuntu2004',
+        #     amps_layer: mpi1,
+        #     netcdf: "false"
+        #   }
+        # - {
+        #     name: "Ubuntu 18.04 Kokkos Build",
+        #     os: ubuntu-20.04,
+        #     cc: "gcc", cxx: "g++",
+        #     python: "false",
+        #     backend: "kokkos",
+        #     cudaos: 'ubuntu2004',
+        #     amps_layer: mpi1,
+        #     netcdf: "false"
+        #   }
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -10,15 +10,15 @@ jobs:
       # fail-fast: true
       matrix:
         config:
-        - {
-            name: "Ubuntu 22.04",
-            os: ubuntu-22.04,
-            cudaos: 'ubuntu2204',
-            python: "false",
-            backend: "none",
-            amps_layer: mpi1,
-            netcdf: "true"
-          }
+        # - {
+        #     name: "Ubuntu 22.04",
+        #     os: ubuntu-22.04,
+        #     cudaos: 'ubuntu2204',
+        #     python: "false",
+        #     backend: "none",
+        #     amps_layer: mpi1,
+        #     netcdf: "true"
+        #   }
         - {
             name: "Ubuntu 20.04 OASIS3-MCT Build",
             os: ubuntu-20.04,

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -38,7 +38,7 @@ jobs:
             netcdf: "true"
           }
         # - {
-        #     name: "Ubuntu 18.04 Python",
+        #     name: "Ubuntu 20.04 Python",
         #     os: ubuntu-20.04,
         #     cudaos: 'ubuntu2004',
         #     python: "true",
@@ -47,7 +47,7 @@ jobs:
         #     netcdf: "false"
         #   }
         # - {
-        #     name: "Ubuntu 18.04 OMP",
+        #     name: "Ubuntu 20.04 OMP",
         #     os: ubuntu-20.04,
         #     cudaos: 'ubuntu2004',
         #     python: "false",
@@ -56,7 +56,7 @@ jobs:
         #     netcdf: "false"
         #   }
         # - {
-        #     name: "Ubuntu 18.04 CUDA Build",
+        #     name: "Ubuntu 20.04 CUDA Build",
         #     os: ubuntu-20.04,
         #     cc: "gcc", cxx: "g++",
         #     python: "false",
@@ -66,7 +66,7 @@ jobs:
         #     netcdf: "false"
         #   }
         # - {
-        #     name: "Ubuntu 18.04 Kokkos Build",
+        #     name: "Ubuntu 20.04 Kokkos Build",
         #     os: ubuntu-20.04,
         #     cc: "gcc", cxx: "g++",
         #     python: "false",
@@ -85,8 +85,8 @@ jobs:
         sudo apt-get -qq update
         sudo apt -qq install gfortran libhdf5-openmpi-dev libhdf5-openmpi-103 hdf5-helpers tcl-dev tk-dev libcurl4 libcurl4-gnutls-dev
 
-    - name: Package Install 18.04 CUDA
-      if: (matrix.config.backend == 'cuda' || matrix.config.backend == 'kokkos') && matrix.config.os == 'ubuntu-18.04'
+    - name: Package Install 20.04 CUDA
+      if: (matrix.config.backend == 'cuda' || matrix.config.backend == 'kokkos') && matrix.config.os == 'ubuntu-20.04'
       run: |
         sudo apt-get -qq update
         sudo apt-get -qq install -y software-properties-common
@@ -95,8 +95,8 @@ jobs:
         sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 78BD65473CB3BD13
         sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 6B05F25D762E3157
 
-    - name: Package Install 18.04
-      if: matrix.config.os == 'ubuntu-18.04'
+    - name: Package Install 20.04
+      if: matrix.config.os == 'ubuntu-20.04'
       run: |
         sudo apt-get -qq update
         sudo apt -qq install gfortran libhdf5-openmpi-dev libhdf5-openmpi-100 hdf5-helpers tcl-dev tk-dev libcurl4 libcurl4-gnutls-dev

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -10,24 +10,24 @@ jobs:
       # fail-fast: true
       matrix:
         config:
-        # - {
-        #     name: "Ubuntu 22.04",
-        #     os: ubuntu-22.04,
-        #     cudaos: 'ubuntu2204',
-        #     python: "false",
-        #     backend: "none",
-        #     amps_layer: mpi1,
-        #     netcdf: "true"
-        #   }
-        # - {
-        #     name: "Ubuntu 20.04 OASIS3-MCT Build",
-        #     os: ubuntu-20.04,
-        #     cudaos: 'ubuntu2004',
-        #     python: "false",
-        #     backend: "omp",
-        #     amps_layer: oas3,
-        #     netcdf: "true"
-        #   }
+        - {
+            name: "Ubuntu 22.04",
+            os: ubuntu-22.04,
+            cudaos: 'ubuntu2204',
+            python: "false",
+            backend: "none",
+            amps_layer: mpi1,
+            netcdf: "true"
+          }
+        - {
+            name: "Ubuntu 20.04 OASIS3-MCT Build",
+            os: ubuntu-20.04,
+            cudaos: 'ubuntu2004',
+            python: "false",
+            backend: "omp",
+            amps_layer: oas3,
+            netcdf: "true"
+          }
         - {
             name: "Ubuntu 20.04",
             os: ubuntu-20.04,
@@ -46,35 +46,35 @@ jobs:
             amps_layer: mpi1,
             netcdf: "false"
           }
-        # - {
-        #     name: "Ubuntu 20.04 OMP",
-        #     os: ubuntu-20.04,
-        #     cudaos: 'ubuntu2004',
-        #     python: "false",
-        #     backend: "omp",
-        #     amps_layer: mpi1,
-        #     netcdf: "false"
-        #   }
-        # - {
-        #     name: "Ubuntu 20.04 CUDA Build",
-        #     os: ubuntu-20.04,
-        #     cc: "gcc", cxx: "g++",
-        #     python: "false",
-        #     backend: "cuda",
-        #     cudaos: 'ubuntu2004',
-        #     amps_layer: mpi1,
-        #     netcdf: "false"
-        #   }
-        # - {
-        #     name: "Ubuntu 20.04 Kokkos Build",
-        #     os: ubuntu-20.04,
-        #     cc: "gcc", cxx: "g++",
-        #     python: "false",
-        #     backend: "kokkos",
-        #     cudaos: 'ubuntu2004',
-        #     amps_layer: mpi1,
-        #     netcdf: "false"
-        #   }
+        - {
+            name: "Ubuntu 20.04 OMP",
+            os: ubuntu-20.04,
+            cudaos: 'ubuntu2004',
+            python: "false",
+            backend: "omp",
+            amps_layer: mpi1,
+            netcdf: "false"
+          }
+        - {
+            name: "Ubuntu 20.04 CUDA Build",
+            os: ubuntu-20.04,
+            cc: "gcc", cxx: "g++",
+            python: "false",
+            backend: "cuda",
+            cudaos: 'ubuntu2004',
+            amps_layer: mpi1,
+            netcdf: "false"
+          }
+        - {
+            name: "Ubuntu 20.04 Kokkos Build",
+            os: ubuntu-20.04,
+            cc: "gcc", cxx: "g++",
+            python: "false",
+            backend: "kokkos",
+            cudaos: 'ubuntu2004',
+            amps_layer: mpi1,
+            netcdf: "false"
+          }
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -2,6 +2,7 @@ name: ParFlow CI Test
 
 on: [push, pull_request]
 
+
 jobs:
   build:
     name: ${{ matrix.config.name }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -471,10 +471,8 @@ if ( ${PARFLOW_HAVE_MALLOC_H} )
 endif ( ${PARFLOW_HAVE_MALLOC_H} )
 
 # Check for mallinfo
+check_symbol_exists(mallinfo2 malloc.h PARFLOW_HAVE_MALLINFO2)
 check_symbol_exists(mallinfo malloc.h PARFLOW_HAVE_MALLINFO)
-if ( ${PARFLOW_HAVE_MALLINFO} )
-  set(HAVE_MALLINFO ${PARFLOW_HAVE_MALLINFO})
-endif ( ${PARFLOW_HAVE_MALLINFO} )
 
 option(PARFLOW_HAVE_CLM "Compile with CLM" "OFF")
 

--- a/cmake/parflow_config.h.in
+++ b/cmake/parflow_config.h.in
@@ -59,8 +59,8 @@
 #cmakedefine PARFLOW_HAVE_MALLOC_H
 #cmakedefine HAVE_MALLOC_H
 
+#cmakedefine PARFLOW_HAVE_MALLINFO2
 #cmakedefine PARFLOW_HAVE_MALLINFO
-#cmakedefine HAVE_MALLINFO
 
 #cmakedefine PARFLOW_HAVE_ETRACE
 

--- a/misc/build_scripts/build.oasis3.ubuntu20.04
+++ b/misc/build_scripts/build.oasis3.ubuntu20.04
@@ -26,10 +26,10 @@ MPI_INCLUDE = $(MPIDIR)/include
 MPILIB      = -L$(MPIDIR)/lib -lmpi
 #
 # NETCDF library of the system
-NETCDF_INCLUDE1 = /usr/include
+NETCDF_INCLUDE1 = ${PARFLOW_DEP_DIR}/include
 # netcdf.mod and hdf5.mod
-NETCDF_INCLUDE2 = /usr/include/hdf5/openmpi
-NETCDF_LIBRARY  =  -L/usr/lib/x86_64-linux-gnu -lnetcdff -lnetcdf
+NETCDF_INCLUDE2 = ${PARFLOW_DEP_DIR}/include
+NETCDF_LIBRARY  =  -L/${PARLFLOW_DEP_DIR}/lib -lnetcdff -lnetcdf
 #
 # Compiling and other commands
 MAKE        = make

--- a/pfsimulator/parflow_lib/problem_phase_rel_perm.c
+++ b/pfsimulator/parflow_lib/problem_phase_rel_perm.c
@@ -196,6 +196,9 @@ VanGTable *VanGComputeTable(
     }
   }
 
+  // GCC 11.3.0 WITH optimization warns that del is possibly used without initialization.
+  // This silences the warning.   Looks like a false warning, what is the opt doing?
+  memset(del, num_sample_points+1, sizeof(double));
   // begin monotonic spline (see Fritsch and Carlson, SIAM J. Num. Anal., 17 (2), 1980)
   for (index = 0; index < num_sample_points; index++)
   {


### PR DESCRIPTION
Update NetCDF used in the CI suite due to compilation issues with previous version and current GCC compilers.
Update image used in the CI suite for the non-CUDA/OASIS3 builds; 18.03 image is deprecated on GitHub.
Fix warning messages coming from GCC 11.3.0 and optimized builds.
Updated deprecated mallinfo command.