### PR TITLE
Error in Haverkamp saturation formula

### DIFF
--- a/docs/user_manual/keys.rst
+++ b/docs/user_manual/keys.rst
@@ -2714,7 +2714,7 @@ in the following form :cite:p:`Haverkamp-Vauclin81`,
 .. math::
 
    \begin{aligned}
-   s(p) = \frac{\alpha(s_{sat} - s_{res})}{A + p^{\gamma}} + s_{res},\end{aligned}
+   s(p) = \frac{\A(s_{sat} - s_{res})}{A + p^{\gamma}} + s_{res},\end{aligned}
 
 where :math:`A` and :math:`\gamma` are soil parameters, on each region.
 The **Data** specification is currently unsupported but will later mean


### PR DESCRIPTION
Typo in Haverkamp saturation formula: alpha replaced with A.

Correct formula from:

Haverkamp, R. and Vauclin, M. (1981), A Comparative Study of Three Forms of the Richard Equation Used for Predicting One-Dimensional Infiltration in Unsaturated Soil. Soil Science Society of America Journal, 45: 13-20. https://doi.org/10.2136/sssaj1981.03615995004500010003x