### PR TITLE
Python tests optional dependencies fixes #367

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -10,6 +10,7 @@ ParFlow development and bug-fixes would not be possible without contributions of
 * Documentation updates
 * 
 
+
 ## User Visible Changes
 
 ### DockerHub Container has Python and TCL support.

--- a/test/python/CMakeLists.txt
+++ b/test/python/CMakeLists.txt
@@ -89,12 +89,16 @@ if ( ${PARFLOW_AMPS_LAYER} IN_LIST PARFLOW_AMPS_LAYER_REQUIRE_MPI )
     list(APPEND PARALLEL_2DTOPO_TESTS
       default_overland
       default_overland.pfmg.jac
-      default_overland.pfmg_octree.jac
       default_overland.pfmg_octree.fulljac
       LW_var_dz
       LW_var_dz_spinup
       overland_slopingslab_KWE
       richards_box_proctest_vardz)
+
+    if(${PARFLOW_HAVE_SILO})
+      list(APPEND PARALLEL_2DTOPO_TESTS
+	default_overland.pfmg_octree.jac)
+    endif()
   endif()
 
 endif()

--- a/test/python/clm/CMakeLists.txt
+++ b/test/python/clm/CMakeLists.txt
@@ -1,17 +1,19 @@
 include(ParflowTest)
 
-if(PARFLOW_HAVE_CLM OR DEFINED ENV{PARFLOW_DIR})
-  set(CLM_TESTS
-    clm-reuse
-  )
-  set(CLM_2D_TESTS
+set(CLM_TESTS)
+set(CLM_2D_TESTS)
+
+if (${PARFLOW_HAVE_CLM} AND ${PARFLOW_HAVE_HYPRE})
+  list(APPEND CLM_TESTS
+    clm-reuse)
+
+  list(APPEND CLM_2D_TESTS
     clm
     clm_varDZ
     clm.jac
     clm_forc_veg
     clm_4levels
-    clm_slope
-  )
+    clm_slope)
 endif()
 
 

--- a/test/python/clm/CMakeLists.txt
+++ b/test/python/clm/CMakeLists.txt
@@ -9,12 +9,15 @@ if (${PARFLOW_HAVE_CLM})
       clm-reuse)
 
     list(APPEND CLM_2D_TESTS
-      clm
-      clm_varDZ
-      clm.jac
-      clm_forc_veg
-      clm_4levels
       clm_slope)
+    if (${PARFLOW_HAVE_SILO})
+      list(APPEND CLM_2D_TESTS
+	clm
+	clm_varDZ
+	clm.jac
+	clm_forc_veg
+	clm_4levels)
+    endif()
   endif()
 endif()
 

--- a/test/python/clm/CMakeLists.txt
+++ b/test/python/clm/CMakeLists.txt
@@ -3,17 +3,19 @@ include(ParflowTest)
 set(CLM_TESTS)
 set(CLM_2D_TESTS)
 
-if (${PARFLOW_HAVE_CLM} AND ${PARFLOW_HAVE_HYPRE})
-  list(APPEND CLM_TESTS
-    clm-reuse)
+if (${PARFLOW_HAVE_CLM})
+  if (${PARFLOW_HAVE_HYPRE})
+    list(APPEND CLM_TESTS
+      clm-reuse)
 
-  list(APPEND CLM_2D_TESTS
-    clm
-    clm_varDZ
-    clm.jac
-    clm_forc_veg
-    clm_4levels
-    clm_slope)
+    list(APPEND CLM_2D_TESTS
+      clm
+      clm_varDZ
+      clm.jac
+      clm_forc_veg
+      clm_4levels
+      clm_slope)
+  endif()
 endif()
 
 

--- a/test/python/new_features/CMakeLists.txt
+++ b/test/python/new_features/CMakeLists.txt
@@ -19,13 +19,17 @@ set(TESTS
   # pfb_mask
   pfidb_pfset
   pfset_test
-  prefix_naming
   selection_methods
-  serial_runs
-  simple-mask
   write_check
   tables_LW
 )
+
+if(${PARFLOW_HAVE_HYPRE})
+  list(APPEND TESTS
+    prefix_naming
+    serial_runs
+    simple-mask)
+endif()
 
 foreach(inputfile ${TESTS})
   pf_add_py_test(${inputfile})

--- a/test/python/new_features/CMakeLists.txt
+++ b/test/python/new_features/CMakeLists.txt
@@ -31,4 +31,6 @@ foreach(inputfile ${TESTS})
   pf_add_py_test(${inputfile})
 endforeach()
 
-add_subdirectory(clm)
+if (${PARFLOW_HAVE_CLM})
+  add_subdirectory(clm)
+endif(${PARFLOW_HAVE_CLM})

--- a/test/python/new_features/clm/CMakeLists.txt
+++ b/test/python/new_features/clm/CMakeLists.txt
@@ -1,9 +1,12 @@
 include(ParflowTest)
 
-set(TESTS
-  washita
-  washita_clm_keys
-)
+set(TESTS)
+
+if (${PARFLOW_HAVE_HYPRE})
+  list(APPEND TESTS
+    washita
+    washita_clm_keys)
+endif()
 
 foreach(inputfile ${TESTS})
   pf_add_py_test(${inputfile})


### PR DESCRIPTION
Added guards to check if optional packages are installed when running python regression tests

The following tests should not run when HYPRE is missing: 
py_prefix_naming
py_serial_runs
py_simple-mask
py_washita
py_washita_clm_keys
py_clm_reuse
py_clm, py_clm_varDZ
py_clm.jac
py_clm_forc_veg
py_clm_4levels
py_clm_slope

The following tests should not run when CLM is missing: 
py_washita
py_washita_clm_keys 

The following tests should not run when SILO is missing: 
py_default_overland.pfmg_octree.jac
py_clm
py_clm_varDZ
py_clm.jac
py_clm_forc_veg
py_clm_4levels