### PR TITLE
Update solver_richards.c to correct digit number in EvapTrans file names

### DIFF
--- a/pfsimulator/parflow_lib/solver_richards.c
+++ b/pfsimulator/parflow_lib/solver_richards.c
@@ -2454,7 +2454,7 @@ AdvanceRichards(PFModule * this_module, double start_time,      /* Starting time
       }
       else if (public_xtra->evap_trans_file_transient)
       {
-        sprintf(filename, "%s.%05d.pfb",
+        sprintf(filename, "%s.%06d.pfb",
                 public_xtra->evap_trans_filename, (istep - 1));
         printf("%d %s %s \n", istep, filename,
                public_xtra->evap_trans_filename);
@@ -2474,7 +2474,7 @@ AdvanceRichards(PFModule * this_module, double start_time,      /* Starting time
             {
               Loopcount = 0;
             }
-            sprintf(filename, "%s.%05d.pfb",
+            sprintf(filename, "%s.%06d.pfb",
                     public_xtra->evap_trans_filename, Loopcount);
             //printf("Using flux file %s \n",filename);
             Loopcount += 1;


### PR DESCRIPTION
Fix minor bug limiting EvapTrans file names to five digits instead of six as forcing input files. See [issue 490](https://github.com/parflow/parflow/issues/490).