### PR TITLE
Compatibility Refactoring for Kokkos starting from v4.0 and a bug Fix for Kokkos (HIP) execution space

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -194,7 +194,7 @@ jobs:
       if: matrix.config.backend == 'kokkos'
       run: |
         if [[ "$CACHE_HIT" != 'true' ]]; then
-          URL=https://github.com/kokkos/kokkos/archive/refs/tags/3.3.01.tar.gz
+          URL=https://github.com/kokkos/kokkos/archive/refs/tags/4.2.01.tar.gz
           mkdir kokkos
           cd kokkos
           curl -L $URL | tar --strip-components=1 -xz

--- a/pfsimulator/amps/mpi1/amps_gpupacking.cpp
+++ b/pfsimulator/amps/mpi1/amps_gpupacking.cpp
@@ -222,7 +222,6 @@ void kokkosMemCpyDeviceToDevice(char *dest, char *src, size_t size){
   Kokkos::deep_copy(dest_view, src_view);
 }
 
-
 /**
  * @brief Device-host memcopy
  *
@@ -240,7 +239,6 @@ void kokkosMemCpyDeviceToHost(char *dest, char *src, size_t size){
 #endif
   Kokkos::deep_copy(dest_view, src_view);
 }
-
 /**
  * @brief Host-device memcopy
  *
@@ -258,7 +256,6 @@ void kokkosMemCpyHostToDevice(char *dest, char *src, size_t size){
 #endif
   Kokkos::deep_copy(dest_view, src_view);
 }
-
 /**
  * @brief Host-host memcopy
  *
@@ -625,11 +622,10 @@ int amps_gpupacking(int action, amps_Invoice inv, int inv_num, char **buffer_out
       return __LINE__;
     }
 #endif
-
     /* Run packing or unpacking kernel */
-    using MDPolicyType_3D = typename Kokkos::Experimental::MDRangePolicy<Kokkos::Experimental::Rank<3> >;
+    using MDPolicyType_3D = typename Kokkos::MDRangePolicy<Kokkos::Rank<3> >;
     MDPolicyType_3D mdpolicy_3d({{0, 0, 0}}, {{len_x, len_y, len_z}});
-
+    
     if(action == AMPS_PACK){
       Kokkos::parallel_for(mdpolicy_3d, KOKKOS_LAMBDA(int i, int j, int k)
       {
@@ -662,11 +658,10 @@ int amps_gpupacking(int action, amps_Invoice inv, int inv_num, char **buffer_out
       });
       inv->flags &= ~AMPS_PACKED;
     }
-
     pos += size;  
     ptr = ptr->next;
   }
-
+  
   /* Check that the size is calculated right */
   // if(pos != amps_sizeof_invoice(amps_CommWorld, inv)){
     // printf("ERROR at %s:%d: The size does not match the invoice size\n", __FILE__, __LINE__);

--- a/pfsimulator/amps/mpi1/amps_gpupacking.cpp
+++ b/pfsimulator/amps/mpi1/amps_gpupacking.cpp
@@ -347,18 +347,14 @@ void amps_gpu_free_bufs(){
 void amps_gpu_finalize(){
   amps_gpu_free_bufs();
   amps_gpu_destroy_streams();
-  if(Kokkos::is_initialized) Kokkos::finalize();
+  if(Kokkos::is_initialized() && !Kokkos::is_finalized()) Kokkos::finalize();
 }
 
 /**
  * @brief Initialize Kokkos if not initialized
  */
 void amps_kokkos_initialization(){
-  if(!Kokkos::is_initialized()){
-    Kokkos::InitArguments args;
-    args.ndevices = 1;
-    Kokkos::initialize(args);  
-  }
+  if(!Kokkos::is_initialized()) Kokkos::initialize();
 }
 
 /**

--- a/pfsimulator/parflow_lib/pf_kokkos.cpp
+++ b/pfsimulator/parflow_lib/pf_kokkos.cpp
@@ -73,7 +73,7 @@ void kokkosInit(){
  * @brief Finalize Kokkos
  */
 void kokkosFinalize(){
-  if(Kokkos::is_initialized) Kokkos::finalize();
+  if(Kokkos::is_initialized && !Kokkos::is_finalized) Kokkos::finalize();
 }
 
 }

--- a/pfsimulator/parflow_lib/pf_kokkos.cpp
+++ b/pfsimulator/parflow_lib/pf_kokkos.cpp
@@ -64,16 +64,14 @@ void kokkosMemSet(char *ptr, size_t size){
  * @brief Initialize Kokkos
  */
 void kokkosInit(){
-  Kokkos::InitArguments args;
-  args.ndevices = 1;
-  Kokkos::initialize(args);    
+  if(!Kokkos::is_initialized()) Kokkos::initialize();
 }
 
 /**
  * @brief Finalize Kokkos
  */
 void kokkosFinalize(){
-  if(Kokkos::is_initialized && !Kokkos::is_finalized) Kokkos::finalize();
+  if(Kokkos::is_initialized() && !Kokkos::is_finalized()) Kokkos::finalize();
 }
 
 }

--- a/pfsimulator/parflow_lib/pf_kokkosloops.h
+++ b/pfsimulator/parflow_lib/pf_kokkosloops.h
@@ -219,7 +219,7 @@ static const int FDIR_TABLE[6][3] = {
         loop_body;                                                                  \
       };                                                                            \
                                                                                     \
-    using MDPolicyType_3D = typename Kokkos::Experimental::MDRangePolicy<Kokkos::Experimental::Rank<3> >;\
+    using MDPolicyType_3D = typename Kokkos::MDRangePolicy<Kokkos::Rank<3> >;       \
     MDPolicyType_3D mdpolicy_3d({{0, 0, 0}}, {{nx, ny, nz}});                       \
     Kokkos::parallel_for(mdpolicy_3d, lambda_body);                                 \
                                                                                     \
@@ -260,7 +260,7 @@ static const int FDIR_TABLE[6][3] = {
         loop_body;                                                                  \
       };                                                                            \
                                                                                     \
-    using MDPolicyType_3D = typename Kokkos::Experimental::MDRangePolicy<Kokkos::Experimental::Rank<3> >;\
+    using MDPolicyType_3D = typename Kokkos::MDRangePolicy<Kokkos::Rank<3> >;       \
     MDPolicyType_3D mdpolicy_3d({{0, 0, 0}}, {{nx, ny, nz}});                       \
     Kokkos::parallel_for(mdpolicy_3d, lambda_body);                                 \
                                                                                     \
@@ -306,7 +306,7 @@ static const int FDIR_TABLE[6][3] = {
         loop_body;                                                                  \
       };                                                                            \
                                                                                     \
-    using MDPolicyType_3D = typename Kokkos::Experimental::MDRangePolicy<Kokkos::Experimental::Rank<3> >;\
+    using MDPolicyType_3D = typename Kokkos::MDRangePolicy<Kokkos::Rank<3> >;       \
     MDPolicyType_3D mdpolicy_3d({{0, 0, 0}}, {{nx, ny, nz}});                       \
     Kokkos::parallel_for(mdpolicy_3d, lambda_body);                                 \
                                                                                     \
@@ -349,7 +349,7 @@ static const int FDIR_TABLE[6][3] = {
         lambda_body(i, j, k, lsum);                                                 \
       };                                                                            \
                                                                                     \
-    using MDPolicyType_3D = typename Kokkos::Experimental::MDRangePolicy<Kokkos::Experimental::Rank<3> >;\
+    using MDPolicyType_3D = typename Kokkos::MDRangePolicy<Kokkos::Rank<3> >;       \
     MDPolicyType_3D mdpolicy_3d({{0, 0, 0}}, {{nx, ny, nz}});                       \
     typedef function_traits<decltype(lambda_body)> traits;                          \
     if(std::is_same<traits::result_type, struct ReduceSumType<double>>::value)      \
@@ -411,7 +411,7 @@ static const int FDIR_TABLE[6][3] = {
         lambda_body(i, j, k, lsum);                                                 \
       };                                                                            \
                                                                                     \
-    using MDPolicyType_3D = typename Kokkos::Experimental::MDRangePolicy<Kokkos::Experimental::Rank<3> >;\
+    using MDPolicyType_3D = typename Kokkos::MDRangePolicy<Kokkos::Rank<3> >;       \
     MDPolicyType_3D mdpolicy_3d({{0, 0, 0}}, {{nx, ny, nz}});                       \
     typedef function_traits<decltype(lambda_body)> traits;                          \
     if(std::is_same<traits::result_type, struct ReduceSumType<double>>::value)      \
@@ -490,7 +490,7 @@ static const int FDIR_TABLE[6][3] = {
             }                                                                       \
           };                                                                        \
                                                                                     \
-        using MDPolicyType_3D = typename Kokkos::Experimental::MDRangePolicy<Kokkos::Experimental::Rank<3> >;\
+        using MDPolicyType_3D = typename Kokkos::MDRangePolicy<Kokkos::Rank<3> >;   \
         MDPolicyType_3D mdpolicy_3d({{0, 0, 0}}, {{PV_nx, PV_ny, PV_nz}});          \
         Kokkos::parallel_for(mdpolicy_3d, lambda_body);                             \
         Kokkos::fence();                                                            \
@@ -524,7 +524,7 @@ static const int FDIR_TABLE[6][3] = {
           }                                                                         \
         };                                                                          \
                                                                                     \
-      using MDPolicyType_3D = typename Kokkos::Experimental::MDRangePolicy<Kokkos::Experimental::Rank<3> >;\
+      using MDPolicyType_3D = typename Kokkos::MDRangePolicy<Kokkos::Rank<3> >;     \
       MDPolicyType_3D mdpolicy_3d({{0, 0, 0}}, {{nx_gpu, ny_gpu, nz_gpu}});         \
       Kokkos::parallel_for(mdpolicy_3d, lambda_body);                               \
       Kokkos::fence();                                                              \
@@ -596,7 +596,7 @@ static const int FDIR_TABLE[6][3] = {
               }                                                                     \
             };                                                                      \
                                                                                     \
-          using MDPolicyType_3D = typename Kokkos::Experimental::MDRangePolicy<Kokkos::Experimental::Rank<3> >;\
+          using MDPolicyType_3D = typename Kokkos::MDRangePolicy<Kokkos::Rank<3> >; \
           MDPolicyType_3D mdpolicy_3d({{0, 0, 0}}, {{PV_nx, PV_ny, PV_nz}});        \
           Kokkos::parallel_for(mdpolicy_3d, lambda_body);                           \
           Kokkos::fence();                                                          \
@@ -637,7 +637,7 @@ static const int FDIR_TABLE[6][3] = {
             }                                                                       \
           };                                                                        \
                                                                                     \
-        using MDPolicyType_3D = typename Kokkos::Experimental::MDRangePolicy<Kokkos::Experimental::Rank<3> >;\
+        using MDPolicyType_3D = typename Kokkos::MDRangePolicy<Kokkos::Rank<3> >;   \
         MDPolicyType_3D mdpolicy_3d({{0, 0, 0}}, {{nx_gpu, ny_gpu, nz_gpu}});       \
         Kokkos::parallel_for(mdpolicy_3d, lambda_body);                             \
         Kokkos::fence();                                                            \
@@ -697,7 +697,7 @@ static const int FDIR_TABLE[6][3] = {
           };                                                                        \
         n_prev += nz * ny * nx;                                                     \
                                                                                     \
-        using MDPolicyType_3D = typename Kokkos::Experimental::MDRangePolicy<Kokkos::Experimental::Rank<3> >;\
+        using MDPolicyType_3D = typename Kokkos::MDRangePolicy<Kokkos::Rank<3> >;   \
         MDPolicyType_3D mdpolicy_3d({{0, 0, 0}}, {{nx, ny, nz}});                   \
         Kokkos::parallel_for(mdpolicy_3d, lambda_body);                             \
         Kokkos::fence();                                                            \
@@ -809,7 +809,7 @@ static const int FDIR_TABLE[6][3] = {
             }                                                                       \
           };                                                                        \
                                                                                     \
-        using MDPolicyType_3D = typename Kokkos::Experimental::MDRangePolicy<Kokkos::Experimental::Rank<3> >;\
+        using MDPolicyType_3D = typename Kokkos::MDRangePolicy<Kokkos::Rank<3> >;   \
         MDPolicyType_3D mdpolicy_3d({{0, 0, 0}}, {{nx_gpu, ny_gpu, nz_gpu}});       \
         Kokkos::parallel_for(mdpolicy_3d, lambda_body);                             \
         Kokkos::fence();                                                            \
@@ -867,7 +867,7 @@ static const int FDIR_TABLE[6][3] = {
           loop_body;                                                                \
         };                                                                          \
                                                                                     \
-      using MDPolicyType_3D = typename Kokkos::Experimental::MDRangePolicy<Kokkos::Experimental::Rank<3> >;\
+      using MDPolicyType_3D = typename Kokkos::MDRangePolicy<Kokkos::Rank<3> >;     \
       MDPolicyType_3D mdpolicy_3d({{0, 0, 0}}, {{PV_diff_x, PV_diff_y, PV_diff_z}});\
       Kokkos::parallel_for(mdpolicy_3d, lambda_body);                               \
       Kokkos::fence();                                                              \
@@ -923,7 +923,7 @@ static const int FDIR_TABLE[6][3] = {
           }                                                                         \
         };                                                                          \
                                                                                     \
-      using MDPolicyType_3D = typename Kokkos::Experimental::MDRangePolicy<Kokkos::Experimental::Rank<3> >;\
+      using MDPolicyType_3D = typename Kokkos::MDRangePolicy<Kokkos::Rank<3> >;     \
       MDPolicyType_3D mdpolicy_3d({{0, 0, 0}}, {{nx, ny, nz}});                     \
       Kokkos::parallel_for(mdpolicy_3d, lambda_body);                               \
       Kokkos::fence();                                                              \


### PR DESCRIPTION
This PR refactors deprecated code in for compatibility with Kokkos starting from version v4.0, and resolves a bug related to multiple finalize calls in the Kokkos HIP execution space.

However, further refactoring is required for the Kokkos backend code to remove deprecated code in Kokkos v3.x. Meanwhile, the following CMake configuration can be used to enable support for deprecated code when compiling Kokkos:

`-DKokkos_ENABLE_DEPRECATED_CODE_3=ON`

I have thoroughly tested these changes with various run configurations and variants of the testcase [clayL.tcl](https://github.com/parflow/parflow/blob/master/test/tcl/clayL.tcl) on
- [JURECA (AMD MI250 GPUs)](https://apps.fz-juelich.de/jsc/hps/jureca/evaluation-platform-overview.html), and
- [LUMI (AMD MI250X GPUs based on the 2nd Gen AMD CDNA architecture)](https://docs.lumi-supercomputer.eu/hardware/lumig/).

Here are additional configuration details of the setup for the runs:

- Kokkos version: 4.2.0
- Parflow version: v3.12.0-26-g24ac8775