### PR TITLE
Pfmask to pfsol compile fix

### DIFF
--- a/pftools/CMakeLists.txt
+++ b/pftools/CMakeLists.txt
@@ -66,6 +66,7 @@ install(TARGETS projecttin DESTINATION bin)
 # Mask utilities
 #-----------------------------------------------------------------------------
 add_executable(pfmask-to-pfsol pfmask-to-pfsol.cpp)
+target_compile_options(pfmask-to-pfsol PUBLIC -ffp-model=precise)
 target_include_directories(pfmask-to-pfsol PUBLIC third_party)
 target_link_libraries(pfmask-to-pfsol pftools)
 install(TARGETS pfmask-to-pfsol DESTINATION bin)

--- a/pftools/CMakeLists.txt
+++ b/pftools/CMakeLists.txt
@@ -66,7 +66,6 @@ install(TARGETS projecttin DESTINATION bin)
 # Mask utilities
 #-----------------------------------------------------------------------------
 add_executable(pfmask-to-pfsol pfmask-to-pfsol.cpp)
-target_compile_options(pfmask-to-pfsol PUBLIC -ffp-model=precise)
 target_include_directories(pfmask-to-pfsol PUBLIC third_party)
 target_link_libraries(pfmask-to-pfsol pftools)
 install(TARGETS pfmask-to-pfsol DESTINATION bin)

--- a/pftools/pfmask-to-pfsol.cpp
+++ b/pftools/pfmask-to-pfsol.cpp
@@ -39,6 +39,7 @@
 #include <cassert>
 #include <cmath>
 #include <limits>
+#include <cfloat>
 
 /*
  * The mask directions.
@@ -356,16 +357,16 @@ int main(int argc, char **argv)
     TCLAP::ValueArg<int> sideArg("","side-patch-label","Side index",false,3,"int");
     cmd.add( sideArg );
 
-    TCLAP::ValueArg<float> zTopArg("","z-top","Set top of domain",false,NAN,"float");
+    TCLAP::ValueArg<float> zTopArg("","z-top","Set top of domain",false,FLT_MIN,"float");
     cmd.add( zTopArg );
 
-    TCLAP::ValueArg<float> zBotArg("","z-bottom","Set bottom of domain",false,NAN,"float");
+    TCLAP::ValueArg<float> zBotArg("","z-bottom","Set bottom of domain",false,FLT_MIN,"float");
     cmd.add( zBotArg );
 
-    TCLAP::ValueArg<float> dxArg("","dx","Set DX",false,NAN,"float");
+    TCLAP::ValueArg<float> dxArg("","dx","Set DX",false,FLT_MIN,"float");
     cmd.add( dxArg );
     
-    TCLAP::ValueArg<float> dyArg("","dy","Set DY",false,NAN,"float");
+    TCLAP::ValueArg<float> dyArg("","dy","Set DY",false,FLT_MIN,"float");
     cmd.add( dyArg );
 
     TCLAP::ValueArg<string>* maskFilenamesArgs[g_maskNames.size()];
@@ -403,7 +404,7 @@ int main(int argc, char **argv)
     side = sideArg.getValue();;
     zTop = zTopArg.getValue();;
     zBot = zBotArg.getValue();;
-    dx = dyArg.getValue();
+    dx = dxArg.getValue();
     dy = dyArg.getValue();
 
   }
@@ -441,18 +442,18 @@ int main(int argc, char **argv)
   sx = DataboxX(databox[0]);
   sy = DataboxY(databox[0]);
 
-  if(isnan(dx))
+  if(dx == FLT_MIN)
   {
     dx = DataboxDx(databox[0]);
   }
 
-  if(isnan(dy))
+  if(dy == FLT_MIN)
   {
     dy = DataboxDy(databox[0]);
   }
 
   // If user specifies Top/Bottom on command line override defaults
-  if(isnan(zBot))
+  if(zBot == FLT_MIN)
   {
     sz = 0.0;
   }
@@ -461,7 +462,7 @@ int main(int argc, char **argv)
     sz = zBot;
   }
 
-  if(isnan(zTop))
+  if(zTop == FLT_MIN)
   {
     dz = DataboxDz(databox[0]);
   }


### PR DESCRIPTION
Compiling parflow with the Intel-OneAPI compiler throws the following warning:

pfmask-to-pfsol.cpp:444:6: warning: comparison with NaN always evaluates to false in fast floating point modes [-Wtautological-constant-compare]
  if(isnan(dx))

There are a few more warnings like that coming from the pfmask-to-pfsol NaN checks.

Basically, NaN checks are ignored in fast floating-point mode, which leads to bugs in the pfmask-to-pfsol script and erroneous solidfiles being produced.

This PR fixes this by replacing the NaN sentinel with FLT_MIN.

Also, a typo on line 406 of pfmask-to-pfsol is corrected.

