### PR TITLE
Fix bug in run.dist()

### DIFF
--- a/pftools/python/parflow/tools/core.py
+++ b/pftools/python/parflow/tools/core.py
@@ -497,7 +497,7 @@ class Run(BaseRun):
         q = kwargs.get('Q', self.Process.Topology.Q)
         r = kwargs.get('R', self.Process.Topology.R)
 
-        with ParflowBinaryReader(pfb_file_full_path) as pfb:
+        with ParflowBinaryReader(pfb_file_full_path, read_sg_info=True) as pfb:
             array = pfb.read_all_subgrids()
             header = pfb.header
 

--- a/pftools/python/parflow/tools/io.py
+++ b/pftools/python/parflow/tools/io.py
@@ -401,22 +401,22 @@ class ParflowBinaryReader:
             self.header['q'] = q
             self.header['r'] = r
 
-        if not ('p' in self.header
-            and 'q' in self.header
-            and 'r' in self.header):
+#        if not ('p' in self.header
+#            and 'q' in self.header
+#            and 'r' in self.header):
             # If p, q, and r aren't given we can precompute them
             # NOTE: This is a bit of a fallback and may not always work
-            eps = 1 - 1e-6
-            first_sg_head = self.read_subgrid_header()
-            self.header['p'] = int((self.header['nx'] / first_sg_head['nx']) + eps)
-            self.header['q'] = int((self.header['ny'] / first_sg_head['ny']) + eps)
-            self.header['r'] = int((self.header['nz'] / first_sg_head['nz']) + eps)
+#            eps = 1 - 1e-6
+#            first_sg_head = self.read_subgrid_header()
+#            self.header['p'] = int((self.header['nx'] / first_sg_head['nx']) + eps)
+#            self.header['q'] = int((self.header['ny'] / first_sg_head['ny']) + eps)
+#            self.header['r'] = int((self.header['nz'] / first_sg_head['nz']) + eps)
 
-        if precompute_subgrid_info:
-            self.compute_subgrid_info()
+#        if precompute_subgrid_info:
+#            self.compute_subgrid_info()
 
-        if read_sg_info:
-            self.read_subgrid_info()
+#        if read_sg_info
+        self.read_subgrid_info()
             
     def close(self):
         self.f.close()

--- a/pftools/python/parflow/tools/io.py
+++ b/pftools/python/parflow/tools/io.py
@@ -401,21 +401,6 @@ class ParflowBinaryReader:
             self.header['q'] = q
             self.header['r'] = r
 
-#        if not ('p' in self.header
-#            and 'q' in self.header
-#            and 'r' in self.header):
-            # If p, q, and r aren't given we can precompute them
-            # NOTE: This is a bit of a fallback and may not always work
-#            eps = 1 - 1e-6
-#            first_sg_head = self.read_subgrid_header()
-#            self.header['p'] = int((self.header['nx'] / first_sg_head['nx']) + eps)
-#            self.header['q'] = int((self.header['ny'] / first_sg_head['ny']) + eps)
-#            self.header['r'] = int((self.header['nz'] / first_sg_head['nz']) + eps)
-
-#        if precompute_subgrid_info:
-#            self.compute_subgrid_info()
-
-#        if read_sg_info
         self.read_subgrid_info()
             
     def close(self):

--- a/test/python/new_features/CMakeLists.txt
+++ b/test/python/new_features/CMakeLists.txt
@@ -17,6 +17,7 @@ set(TESTS
   normalize_location
   os_function
   # pfb_mask
+  pfb_reader
   pfidb_pfset
   pfset_test
   selection_methods

--- a/test/python/new_features/pfb_reader.py
+++ b/test/python/new_features/pfb_reader.py
@@ -1,0 +1,20 @@
+import os
+import numpy as np
+from parflow import Run
+from parflow.tools.io import read_pfb, write_pfb, ParflowBinaryReader
+from parflow.tools.fs import mkdir, get_absolute_path
+
+# Check that Run.dist() works even when grid P, Q, R don't exactly divide
+# nx, ny, nz.
+
+data = np.ones((89, 91))
+run = Run("test_dist", __file__)
+working_dir = get_absolute_path(os.path.join("test_output", "dist"))
+mkdir(working_dir)
+
+path = os.path.join(working_dir, 'data.pfb')
+write_pfb(path, data)
+
+run.dist(path, P=15, Q=15)
+
+run.dist(path, P=14, Q=15)

--- a/test/python/new_features/pfb_reader.py
+++ b/test/python/new_features/pfb_reader.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import numpy as np
 from parflow import Run
 from parflow.tools.io import read_pfb, write_pfb, ParflowBinaryReader
@@ -16,11 +17,11 @@ path = os.path.join(working_dir, 'data.pfb')
 write_pfb(path, data)
 
 run.dist(path, P=15, Q=15)
-rd = ParflowBinaryReader(path)
+rd = ParflowBinaryReader(path, read_sg_info=True)
 if rd.header['p'] != 15 or rd.header['q'] != 15:
     sys.exit(1)
     
 run.dist(path, P=14, Q=15)
-rd = ParflowBinaryReader(path)
+rd = ParflowBinaryReader(path, read_sg_info=True)
 if rd.header['p'] != 14 or rd.header['q'] != 15:
     sys.exit(1)

--- a/test/python/new_features/pfb_reader.py
+++ b/test/python/new_features/pfb_reader.py
@@ -4,8 +4,8 @@ from parflow import Run
 from parflow.tools.io import read_pfb, write_pfb, ParflowBinaryReader
 from parflow.tools.fs import mkdir, get_absolute_path
 
-# Check that Run.dist() works even when grid P, Q, R don't exactly divide
-# nx, ny, nz.
+# Check that the ParflowBinaryReader reads the correct values of p, q, r even
+# when they don't exactly divide nx, ny, nz.
 
 data = np.ones((89, 91))
 run = Run("test_dist", __file__)
@@ -16,5 +16,11 @@ path = os.path.join(working_dir, 'data.pfb')
 write_pfb(path, data)
 
 run.dist(path, P=15, Q=15)
-
+rd = ParflowBinaryReader(path)
+if rd.header['p'] != 15 or rd.header['q'] != 15:
+    sys.exit(1)
+    
 run.dist(path, P=14, Q=15)
+rd = ParflowBinaryReader(path)
+if rd.header['p'] != 14 or rd.header['q'] != 15:
+    sys.exit(1)


### PR DESCRIPTION
run.dist() does not re-distribute well files that have been already been distributed in a way that p, q, r do not exactly divide NX, NY, NZ. The problem lies in trying to "estimate" p, q, r when reading those distributed files in with the ParflowBinaryReader.

This pull request removes the precomputation option (which cannot work if we allow distributing grids unevenly), and adds explicit calculation for p, q, r in the read_subgrid_info. Also, a test for ParflowBinaryReader is added, which distributes and redistributes a pfb file. That test fails with the previous implementation.