### PR TITLE
Remove C files within py-env from uncrustify check

### DIFF
--- a/bin/pfformat
+++ b/bin/pfformat
@@ -102,7 +102,7 @@ function main() {
 
    failed=false
 
-   for i in $(find . -name \*.[ch] | grep -v './build\|third_party')
+   for i in $(find . -name \*.[ch] | grep -v './build\|third_party\|./py-env')
    do
       if $check
       then


### PR DESCRIPTION
If parflow is built with a python environment, those package C files should not be subject to uncrustify checks.