### PR TITLE
Fix tests

### DIFF
--- a/test/python/CMakeLists.txt
+++ b/test/python/CMakeLists.txt
@@ -14,7 +14,6 @@ set(TESTS
   richards_hydrostatic_equilibrium
   indicator_field
   LW_surface_press
-  channelwidth
   overland_tiltedV_MGSemiTest
 )
 
@@ -52,7 +51,8 @@ if(${PARFLOW_HAVE_HYPRE})
     water_balance_y
     water_balance_x
     water_balance_x.hardflow.nojac
-    water_balance_x.hardflow.jac)
+    water_balance_x.hardflow.jac
+    channelwidth)
 endif()
 
 if(${PARFLOW_HAVE_SILO})

--- a/test/python/washita/CMakeLists.txt
+++ b/test/python/washita/CMakeLists.txt
@@ -1,7 +1,5 @@
 include(ParflowTest)
 
-if(PARFLOW_HAVE_HYPRE OR DEFINED ENV{PARFLOW_DIR})
-  if(PARFLOW_HAVE_CLM OR DEFINED ENV{PARFLOW_DIR})
-    pf_add_py_test(LW_Test)
-  endif()
+if(PARFLOW_HAVE_HYPRE AND PARFLOW_HAVE_CLM)
+  pf_add_py_test(LW_Test)
 endif()


### PR DESCRIPTION
Two python tests, channelwitdth and LW require hypre. The LW in particular is always included if PARFLOW_DIR is defined, which leads to the test failing when it should not have been included.