### PR TITLE
Add flag to enable building ParFlow using C++ compiler 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,14 @@ foreach (DEBUG_FLAG "-ggdb" "-g3")
 endforeach ()
 
 #-----------------------------------------------------------------------------
+# The ParFlow C library source will be built as C++ if this flag is set.
+# ParFlow is moving to using C++; this flag is a first step towards that goal.
+# Does not currently change pftools build.
+#-----------------------------------------------------------------------------
+
+set(PARFLOW_BUILD_WITH_CPP FALSE CACHE STRING "Build ParFlow using the C++ compiler.  This flag is principlly for developers.")
+
+#-----------------------------------------------------------------------------
 # Set accelerator backend
 #-----------------------------------------------------------------------------
 set(PARFLOW_ACCELERATOR_BACKEND "none" CACHE STRING "Set accelerator backend")

--- a/pfsimulator/amps/CMakeLists.txt
+++ b/pfsimulator/amps/CMakeLists.txt
@@ -10,6 +10,11 @@ string(REGEX REPLACE "([^;]+)" "common/\\1" COMMON_SRC_FILES "${COMMON_SRC_FILES
 include("${PARFLOW_AMPS_LAYER}/CMakeLists.cmake")
 string(REGEX REPLACE "([^;]+)" "${PARFLOW_AMPS_LAYER}/\\1" AMPS_SRC_FILES "${AMPS_SRC_FILES}")
 
+if( ${PARFLOW_BUILD_WITH_CPP} )
+  set_source_files_properties(${COMMON_SRC_FILES} ${AMPS_SRC_FILES}
+    PROPERTIES LANGUAGE CXX)
+endif()
+
 add_library(amps STATIC ${COMMON_SRC_FILES} ${AMPS_SRC_FILES})
 
 if(${PARFLOW_HAVE_CUDA})

--- a/pfsimulator/amps/mpi1/CMakeLists.cmake
+++ b/pfsimulator/amps/mpi1/CMakeLists.cmake
@@ -18,6 +18,9 @@ set(AMPS_SRC_FILES
   amps_vector.c
   )
 
+set_source_files_properties(${AMPS_SRC_FILES}
+  PROPERTIES LANGUAGE CXX)
+
 if((${PARFLOW_HAVE_CUDA}) AND (NOT (${PARFLOW_HAVE_KOKKOS})))
   list(APPEND AMPS_SRC_FILES amps_gpupacking.cu)
 endif((${PARFLOW_HAVE_CUDA}) AND (NOT (${PARFLOW_HAVE_KOKKOS})))

--- a/pfsimulator/amps/test/src/CMakeLists.txt
+++ b/pfsimulator/amps/test/src/CMakeLists.txt
@@ -48,6 +48,12 @@ set(ALL_TESTS ${SEQUENTIAL_TESTS} ${PARALLEL_TESTS})
 list(REMOVE_DUPLICATES ALL_TESTS)
 
 foreach(test ${ALL_TESTS})
+
+  if( ${PARFLOW_BUILD_WITH_CPP} )
+    set_source_files_properties(${test}.c
+      PROPERTIES LANGUAGE CXX)
+  endif()
+
   add_executable( ${test} ${test}.c)
   target_link_libraries(${test} amps)
   

--- a/pfsimulator/amps/test/src/test13.c
+++ b/pfsimulator/amps/test/src/test13.c
@@ -77,7 +77,7 @@ int main(int argc, char *argv[])
   total_length = ((v1_len - 1) * v1_stride + 1) * v2_len + (v2_stride - 1) * (v2_len - 1);
   total_length = total_length * v3_len + (v2_stride - 1) * (v3_len - 1);
   /* Init Vector */
-  vector = calloc(total_length, sizeof(double));
+  vector = (double*)calloc(total_length, sizeof(double));
 
 
   /* SGS order of args */

--- a/pfsimulator/parflow_exe/CMakeLists.txt
+++ b/pfsimulator/parflow_exe/CMakeLists.txt
@@ -1,4 +1,11 @@
-add_executable(parflow main.c)
+set(MAIN_SRC main.c)
+
+if( ${PARFLOW_BUILD_WITH_CPP} )
+  set_source_files_properties(${MAIN_SRC}
+    PROPERTIES LANGUAGE CXX)
+endif()
+
+add_executable(parflow ${MAIN_SRC})
 
 target_link_libraries(parflow pfsimulator)
 

--- a/pfsimulator/parflow_lib/CMakeLists.txt
+++ b/pfsimulator/parflow_lib/CMakeLists.txt
@@ -257,6 +257,11 @@ else( (${PARFLOW_HAVE_CUDA}) OR (${PARFLOW_HAVE_KOKKOS}) OR (${PARFLOW_HAVE_OMP}
 
 endif( (${PARFLOW_HAVE_CUDA}) OR (${PARFLOW_HAVE_KOKKOS}) OR (${PARFLOW_HAVE_OMP}) )
 
+if( ${PARFLOW_BUILD_WITH_CPP} )
+  set_source_files_properties(${SRC_FILES_ARCH} ${SRC_FILES_CONST}
+    PROPERTIES LANGUAGE CXX)
+endif()
+
 target_link_libraries(pfsimulator pfkinsol amps cjson ${PARFLOW_ETRACE_LIBRARY})
 target_include_directories(pfsimulator PUBLIC "../third_party/cjson")
 

--- a/pfsimulator/parflow_lib/f2c.h
+++ b/pfsimulator/parflow_lib/f2c.h
@@ -142,10 +142,9 @@ struct Namelist {
 };
 typedef struct Namelist Namelist;
 
-#ifndef abs
-#define abs(x) ((x) >= 0 ? (x) : -(x))
+#ifndef pfabs
+#define pfabs(x) ((x) >= 0 ? (x) : -(x))
 #endif
-
 
 #define dabs(x) (doublereal)abs(x)
 

--- a/pfsimulator/parflow_lib/fgetopt.h
+++ b/pfsimulator/parflow_lib/fgetopt.h
@@ -44,7 +44,7 @@ extern int optreset;    /* reset getopt  */
 extern char *optarg;    /* argument associated with option */
 
 #ifndef __cplusplus
-extern int getopt (int ___argc, char *const *___argv, const char *__shortopts);
+extern int getopt(int ___argc, char *const *___argv, const char *__shortopts);
 #endif
 
 #ifdef __cplusplus

--- a/pfsimulator/parflow_lib/fgetopt.h
+++ b/pfsimulator/parflow_lib/fgetopt.h
@@ -33,12 +33,22 @@
 #ifndef GETOPT_H
 #define GETOPT_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 extern int opterr;              /* if error message should be printed */
 extern int optind;              /* index into parent argv vector */
 extern int optopt;              /* character checked for validity */
 extern int optreset;    /* reset getopt  */
 extern char *optarg;    /* argument associated with option */
 
-int getopt(int nargc, char * const nargv[], const char *ostr);
+#ifndef __cplusplus
+extern int getopt (int ___argc, char *const *___argv, const char *__shortopts);
+#endif
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/pfsimulator/parflow_lib/metadata.h
+++ b/pfsimulator/parflow_lib/metadata.h
@@ -34,9 +34,6 @@
 
 #include "cJSON.h"
 
-struct PFModule;
-struct Grid;
-
 // Hide cJSON from the public API so we can switch to other JSON libraries as needed.
 typedef cJSON* MetadataItem;
 

--- a/pfsimulator/parflow_lib/n_vector.c
+++ b/pfsimulator/parflow_lib/n_vector.c
@@ -42,6 +42,11 @@ void SetPf2KinsolData(
   pf2kinsol_data.num_ghost = num_ghost;
 }
 
+/* Kinsol API is in C */
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 N_Vector N_VNew(
                 int   N,
                 void *machEnv)
@@ -56,6 +61,16 @@ N_Vector N_VNew(
   num_ghost = pf2kinsol_data.num_ghost;
   return(NewVectorType(grid, 1, num_ghost, vector_cell_centered));
 }
+
+void N_VFree(
+              N_Vector x)
+{
+  FreeVector(x);
+}
+
+#ifdef __cplusplus
+}
+#endif
 
 void N_VPrint(
               N_Vector x)

--- a/pfsimulator/parflow_lib/n_vector.c
+++ b/pfsimulator/parflow_lib/n_vector.c
@@ -63,7 +63,7 @@ N_Vector N_VNew(
 }
 
 void N_VFree(
-              N_Vector x)
+             N_Vector x)
 {
   FreeVector(x);
 }

--- a/pfsimulator/parflow_lib/n_vector.h
+++ b/pfsimulator/parflow_lib/n_vector.h
@@ -31,10 +31,6 @@
 
 #include "parflow.h"
 
-
-
-#define N_VFree(x)                    FreeVector(x)
-
 #define N_VLinearSum(a, x, b, y, z)   PFVLinearSum(a, x, b, y, z)
 #define N_VConst(c, z)                PFVConstInit(c, z)
 #define N_VProd(x, y, z)              PFVProd(x, y, z)

--- a/pfsimulator/parflow_lib/parflow_proto.h
+++ b/pfsimulator/parflow_lib/parflow_proto.h
@@ -426,9 +426,20 @@ ComputePkg *NewMGSemiRestrictComputePkg(Grid *grid, Stencil *stencil, int sx, in
 
 /* n_vector.c */
 void SetPf2KinsolData(Grid *grid, int num_ghost);
-N_Vector N_VNew(int N, void *machEnv);
 void N_VPrint(N_Vector x);
 void FreeTempVector(Vector *vector);
+
+/* Kinsol API is in C. */
+#ifdef __cplusplus
+extern "C" {
+#endif
+  
+N_Vector N_VNew(int N, void *machEnv);
+void N_VFree(N_Vector x);
+
+#ifdef __cplusplus
+}
+#endif
 
 /* new_endpts.c */
 void NewEndpts(double *alpha, double *beta, double *pp, int *size_ptr, int n, double *a_ptr, double *b_ptr, double *cond_ptr, double ereps);
@@ -1278,6 +1289,10 @@ void InitVectorAll(Vector *v, double value);
 void InitVectorInc(Vector *v, double value, double inc);
 void InitVectorRandom(Vector *v, long seed);
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* vector_utilities.c */
 void PFVLinearSum(double a, Vector *x, double b, Vector *y, Vector *z);
 void PFVConstInit(double c, Vector *z);
@@ -1308,6 +1323,10 @@ void PFVLin2(double a, Vector *x, Vector *y, Vector *z);
 void PFVAxpy(double a, Vector *x, Vector *y);
 void PFVScaleBy(double a, Vector *x);
 void PFVLayerCopy(int a, int b, Vector *x, Vector *y);
+
+#ifdef __cplusplus
+}
+#endif
 
 /* w_jacobi.c */
 void WJacobi(Vector *x, Vector *b, double tol, int zero);

--- a/pfsimulator/parflow_lib/parflow_proto.h
+++ b/pfsimulator/parflow_lib/parflow_proto.h
@@ -433,7 +433,7 @@ void FreeTempVector(Vector *vector);
 #ifdef __cplusplus
 extern "C" {
 #endif
-  
+
 N_Vector N_VNew(int N, void *machEnv);
 void N_VFree(N_Vector x);
 

--- a/pfsimulator/parflow_lib/ratqr.c
+++ b/pfsimulator/parflow_lib/ratqr.c
@@ -174,7 +174,7 @@ L40:
     {
       goto L60;
     }
-    d__3 = (d__1 = d[i], abs(d__1)) + (d__2 = d[i - 1], abs(d__2));
+    d__3 = (d__1 = d[i], pfabs(d__1)) + (d__2 = d[i - 1], pfabs(d__2));
     if (p > epslon_(&d__3))
     {
       goto L80;
@@ -193,7 +193,7 @@ L80:
     q = 0.;
     if (i != *n)
     {
-      q = (d__1 = e[i + 1], abs(d__1));
+      q = (d__1 = e[i + 1], pfabs(d__1));
     }
 /* Computing MIN */
     d__1 = w[i] - p - q;
@@ -226,7 +226,7 @@ L180:
     tot += s;
     delta = w[*n] - s;
     i = *n;
-    f = (d__1 = epslon_(&tot), abs(d__1));
+    f = (d__1 = epslon_(&tot), pfabs(d__1));
     if (*eps1 < f)
     {
       *eps1 = f;
@@ -347,7 +347,7 @@ L300:
 
 L340:
     w[k] = tot;
-    err += abs(delta);
+    err += pfabs(delta);
     bd[k] = err;
     ind[k] = ii;
 /* L360: */
@@ -421,12 +421,12 @@ double epslon_(double *x)
 L10:
   b = a - 1.;
   c = b + b + b;
-  eps = (d__1 = c - 1., abs(d__1));
+  eps = (d__1 = c - 1., pfabs(d__1));
   if (eps == 0.)
   {
     goto L10;
   }
-  ret_val = eps * abs(*x);
+  ret_val = eps * pfabs(*x);
   return ret_val;
 } /* epslon_ */
 

--- a/pfsimulator/parflow_lib/vector_utilities.c
+++ b/pfsimulator/parflow_lib/vector_utilities.c
@@ -72,6 +72,11 @@
 #define ZERO 0.0
 #define ONE  1.0
 
+/* Kinsol API is in C */
+#ifdef __cplusplus
+extern "C"
+#endif
+
 void PFVLinearSum(
 /* LinearSum : z = a * x + b * y              */
                   double  a,
@@ -2077,3 +2082,7 @@ void PFVLayerCopy(
   }
   IncFLOPCount(2 * VectorSize(x));
 }
+
+#ifdef __cpluspus
+}
+#endif

--- a/pfsimulator/parflow_lib/write_clm_netcdf.c
+++ b/pfsimulator/parflow_lib/write_clm_netcdf.c
@@ -213,11 +213,11 @@ int LookUpCLMInventory(char * varName, varNCData **myVarNCData, int *clmIDs)
 
   if (strcmp(varName, "time") == 0)
   {
-    *myVarNCData = malloc(sizeof(varNCData));
+    *myVarNCData = (varNCData*)malloc(sizeof(varNCData));
     (*myVarNCData)->varName = varName;
     (*myVarNCData)->ncType = NC_DOUBLE;
     (*myVarNCData)->dimSize = 1;
-    (*myVarNCData)->dimIDs = malloc((*myVarNCData)->dimSize * sizeof(int));
+    (*myVarNCData)->dimIDs = (int*)malloc((*myVarNCData)->dimSize * sizeof(int));
     (*myVarNCData)->dimIDs[0] = clmIDs[1];
     int timCLMVarID;
     int res = nc_def_var(clmIDs[0], varName, (*myVarNCData)->ncType, (*myVarNCData)->dimSize,
@@ -235,11 +235,11 @@ int LookUpCLMInventory(char * varName, varNCData **myVarNCData, int *clmIDs)
 
   if (strcmp(varName, "t_soil") == 0)
   {
-    *myVarNCData = malloc(sizeof(varNCData));
+    *myVarNCData = (varNCData*)malloc(sizeof(varNCData));
     (*myVarNCData)->varName = varName;
     (*myVarNCData)->ncType = NC_DOUBLE;
     (*myVarNCData)->dimSize = 4;
-    (*myVarNCData)->dimIDs = malloc((*myVarNCData)->dimSize * sizeof(int));
+    (*myVarNCData)->dimIDs = (int*)malloc((*myVarNCData)->dimSize * sizeof(int));
     (*myVarNCData)->dimIDs[0] = clmIDs[1];
     (*myVarNCData)->dimIDs[1] = clmIDs[2];
     (*myVarNCData)->dimIDs[2] = clmIDs[3];
@@ -277,11 +277,11 @@ int LookUpCLMInventory(char * varName, varNCData **myVarNCData, int *clmIDs)
 
   if (strcmp(varName, "eflx_lh_tot") == 0)
   {
-    *myVarNCData = malloc(sizeof(varNCData));
+    *myVarNCData = (varNCData*)malloc(sizeof(varNCData));
     (*myVarNCData)->varName = varName;
     (*myVarNCData)->ncType = NC_DOUBLE;
     (*myVarNCData)->dimSize = 3;
-    (*myVarNCData)->dimIDs = malloc((*myVarNCData)->dimSize * sizeof(int));
+    (*myVarNCData)->dimIDs = (int*)malloc((*myVarNCData)->dimSize * sizeof(int));
     (*myVarNCData)->dimIDs[0] = clmIDs[1];
     (*myVarNCData)->dimIDs[1] = clmIDs[3];
     (*myVarNCData)->dimIDs[2] = clmIDs[4];
@@ -317,11 +317,11 @@ int LookUpCLMInventory(char * varName, varNCData **myVarNCData, int *clmIDs)
 
   if (strcmp(varName, "eflx_lwrad_out") == 0)
   {
-    *myVarNCData = malloc(sizeof(varNCData));
+    *myVarNCData = (varNCData*)malloc(sizeof(varNCData));
     (*myVarNCData)->varName = varName;
     (*myVarNCData)->ncType = NC_DOUBLE;
     (*myVarNCData)->dimSize = 3;
-    (*myVarNCData)->dimIDs = malloc((*myVarNCData)->dimSize * sizeof(int));
+    (*myVarNCData)->dimIDs = (int*)malloc((*myVarNCData)->dimSize * sizeof(int));
     (*myVarNCData)->dimIDs[0] = clmIDs[1];
     (*myVarNCData)->dimIDs[1] = clmIDs[3];
     (*myVarNCData)->dimIDs[2] = clmIDs[4];
@@ -357,11 +357,11 @@ int LookUpCLMInventory(char * varName, varNCData **myVarNCData, int *clmIDs)
 
   if (strcmp(varName, "eflx_sh_tot") == 0)
   {
-    *myVarNCData = malloc(sizeof(varNCData));
+    *myVarNCData = (varNCData*)malloc(sizeof(varNCData));
     (*myVarNCData)->varName = varName;
     (*myVarNCData)->ncType = NC_DOUBLE;
     (*myVarNCData)->dimSize = 3;
-    (*myVarNCData)->dimIDs = malloc((*myVarNCData)->dimSize * sizeof(int));
+    (*myVarNCData)->dimIDs = (int*)malloc((*myVarNCData)->dimSize * sizeof(int));
     (*myVarNCData)->dimIDs[0] = clmIDs[1];
     (*myVarNCData)->dimIDs[1] = clmIDs[3];
     (*myVarNCData)->dimIDs[2] = clmIDs[4];
@@ -397,11 +397,11 @@ int LookUpCLMInventory(char * varName, varNCData **myVarNCData, int *clmIDs)
 
   if (strcmp(varName, "eflx_soil_grnd") == 0)
   {
-    *myVarNCData = malloc(sizeof(varNCData));
+    *myVarNCData = (varNCData*)malloc(sizeof(varNCData));
     (*myVarNCData)->varName = varName;
     (*myVarNCData)->ncType = NC_DOUBLE;
     (*myVarNCData)->dimSize = 3;
-    (*myVarNCData)->dimIDs = malloc((*myVarNCData)->dimSize * sizeof(int));
+    (*myVarNCData)->dimIDs = (int*)malloc((*myVarNCData)->dimSize * sizeof(int));
     (*myVarNCData)->dimIDs[0] = clmIDs[1];
     (*myVarNCData)->dimIDs[1] = clmIDs[3];
     (*myVarNCData)->dimIDs[2] = clmIDs[4];
@@ -437,11 +437,11 @@ int LookUpCLMInventory(char * varName, varNCData **myVarNCData, int *clmIDs)
 
   if (strcmp(varName, "qflx_evap_tot") == 0)
   {
-    *myVarNCData = malloc(sizeof(varNCData));
+    *myVarNCData = (varNCData*)malloc(sizeof(varNCData));
     (*myVarNCData)->varName = varName;
     (*myVarNCData)->ncType = NC_DOUBLE;
     (*myVarNCData)->dimSize = 3;
-    (*myVarNCData)->dimIDs = malloc((*myVarNCData)->dimSize * sizeof(int));
+    (*myVarNCData)->dimIDs = (int*)malloc((*myVarNCData)->dimSize * sizeof(int));
     (*myVarNCData)->dimIDs[0] = clmIDs[1];
     (*myVarNCData)->dimIDs[1] = clmIDs[3];
     (*myVarNCData)->dimIDs[2] = clmIDs[4];
@@ -477,11 +477,11 @@ int LookUpCLMInventory(char * varName, varNCData **myVarNCData, int *clmIDs)
 
   if (strcmp(varName, "qflx_evap_grnd") == 0)
   {
-    *myVarNCData = malloc(sizeof(varNCData));
+    *myVarNCData = (varNCData*)malloc(sizeof(varNCData));
     (*myVarNCData)->varName = varName;
     (*myVarNCData)->ncType = NC_DOUBLE;
     (*myVarNCData)->dimSize = 3;
-    (*myVarNCData)->dimIDs = malloc((*myVarNCData)->dimSize * sizeof(int));
+    (*myVarNCData)->dimIDs = (int*)malloc((*myVarNCData)->dimSize * sizeof(int));
     (*myVarNCData)->dimIDs[0] = clmIDs[1];
     (*myVarNCData)->dimIDs[1] = clmIDs[3];
     (*myVarNCData)->dimIDs[2] = clmIDs[4];
@@ -517,11 +517,11 @@ int LookUpCLMInventory(char * varName, varNCData **myVarNCData, int *clmIDs)
 
   if (strcmp(varName, "qflx_evap_soi") == 0)
   {
-    *myVarNCData = malloc(sizeof(varNCData));
+    *myVarNCData = (varNCData*)malloc(sizeof(varNCData));
     (*myVarNCData)->varName = varName;
     (*myVarNCData)->ncType = NC_DOUBLE;
     (*myVarNCData)->dimSize = 3;
-    (*myVarNCData)->dimIDs = malloc((*myVarNCData)->dimSize * sizeof(int));
+    (*myVarNCData)->dimIDs = (int*)malloc((*myVarNCData)->dimSize * sizeof(int));
     (*myVarNCData)->dimIDs[0] = clmIDs[1];
     (*myVarNCData)->dimIDs[1] = clmIDs[3];
     (*myVarNCData)->dimIDs[2] = clmIDs[4];
@@ -557,11 +557,11 @@ int LookUpCLMInventory(char * varName, varNCData **myVarNCData, int *clmIDs)
 
   if (strcmp(varName, "qflx_evap_veg") == 0)
   {
-    *myVarNCData = malloc(sizeof(varNCData));
+    *myVarNCData = (varNCData*)malloc(sizeof(varNCData));
     (*myVarNCData)->varName = varName;
     (*myVarNCData)->ncType = NC_DOUBLE;
     (*myVarNCData)->dimSize = 3;
-    (*myVarNCData)->dimIDs = malloc((*myVarNCData)->dimSize * sizeof(int));
+    (*myVarNCData)->dimIDs = (int*)malloc((*myVarNCData)->dimSize * sizeof(int));
     (*myVarNCData)->dimIDs[0] = clmIDs[1];
     (*myVarNCData)->dimIDs[1] = clmIDs[3];
     (*myVarNCData)->dimIDs[2] = clmIDs[4];
@@ -597,11 +597,11 @@ int LookUpCLMInventory(char * varName, varNCData **myVarNCData, int *clmIDs)
 
   if (strcmp(varName, "qflx_tran_veg") == 0)
   {
-    *myVarNCData = malloc(sizeof(varNCData));
+    *myVarNCData = (varNCData*)malloc(sizeof(varNCData));
     (*myVarNCData)->varName = varName;
     (*myVarNCData)->ncType = NC_DOUBLE;
     (*myVarNCData)->dimSize = 3;
-    (*myVarNCData)->dimIDs = malloc((*myVarNCData)->dimSize * sizeof(int));
+    (*myVarNCData)->dimIDs = (int*)malloc((*myVarNCData)->dimSize * sizeof(int));
     (*myVarNCData)->dimIDs[0] = clmIDs[1];
     (*myVarNCData)->dimIDs[1] = clmIDs[3];
     (*myVarNCData)->dimIDs[2] = clmIDs[4];
@@ -637,11 +637,11 @@ int LookUpCLMInventory(char * varName, varNCData **myVarNCData, int *clmIDs)
 
   if (strcmp(varName, "qflx_infl") == 0)
   {
-    *myVarNCData = malloc(sizeof(varNCData));
+    *myVarNCData = (varNCData*)malloc(sizeof(varNCData));
     (*myVarNCData)->varName = varName;
     (*myVarNCData)->ncType = NC_DOUBLE;
     (*myVarNCData)->dimSize = 3;
-    (*myVarNCData)->dimIDs = malloc((*myVarNCData)->dimSize * sizeof(int));
+    (*myVarNCData)->dimIDs = (int*)malloc((*myVarNCData)->dimSize * sizeof(int));
     (*myVarNCData)->dimIDs[0] = clmIDs[1];
     (*myVarNCData)->dimIDs[1] = clmIDs[3];
     (*myVarNCData)->dimIDs[2] = clmIDs[4];
@@ -677,11 +677,11 @@ int LookUpCLMInventory(char * varName, varNCData **myVarNCData, int *clmIDs)
 
   if (strcmp(varName, "swe_out") == 0)
   {
-    *myVarNCData = malloc(sizeof(varNCData));
+    *myVarNCData = (varNCData*)malloc(sizeof(varNCData));
     (*myVarNCData)->varName = varName;
     (*myVarNCData)->ncType = NC_DOUBLE;
     (*myVarNCData)->dimSize = 3;
-    (*myVarNCData)->dimIDs = malloc((*myVarNCData)->dimSize * sizeof(int));
+    (*myVarNCData)->dimIDs = (int*)malloc((*myVarNCData)->dimSize * sizeof(int));
     (*myVarNCData)->dimIDs[0] = clmIDs[1];
     (*myVarNCData)->dimIDs[1] = clmIDs[3];
     (*myVarNCData)->dimIDs[2] = clmIDs[4];
@@ -717,11 +717,11 @@ int LookUpCLMInventory(char * varName, varNCData **myVarNCData, int *clmIDs)
 
   if (strcmp(varName, "t_grnd") == 0)
   {
-    *myVarNCData = malloc(sizeof(varNCData));
+    *myVarNCData = (varNCData*)malloc(sizeof(varNCData));
     (*myVarNCData)->varName = varName;
     (*myVarNCData)->ncType = NC_DOUBLE;
     (*myVarNCData)->dimSize = 3;
-    (*myVarNCData)->dimIDs = malloc((*myVarNCData)->dimSize * sizeof(int));
+    (*myVarNCData)->dimIDs = (int*)malloc((*myVarNCData)->dimSize * sizeof(int));
     (*myVarNCData)->dimIDs[0] = clmIDs[1];
     (*myVarNCData)->dimIDs[1] = clmIDs[3];
     (*myVarNCData)->dimIDs[2] = clmIDs[4];
@@ -757,11 +757,11 @@ int LookUpCLMInventory(char * varName, varNCData **myVarNCData, int *clmIDs)
 
   if (strcmp(varName, "qflx_qirr") == 0)
   {
-    *myVarNCData = malloc(sizeof(varNCData));
+    *myVarNCData = (varNCData*)malloc(sizeof(varNCData));
     (*myVarNCData)->varName = varName;
     (*myVarNCData)->ncType = NC_DOUBLE;
     (*myVarNCData)->dimSize = 3;
-    (*myVarNCData)->dimIDs = malloc((*myVarNCData)->dimSize * sizeof(int));
+    (*myVarNCData)->dimIDs = (int*)malloc((*myVarNCData)->dimSize * sizeof(int));
     (*myVarNCData)->dimIDs[0] = clmIDs[1];
     (*myVarNCData)->dimIDs[1] = clmIDs[3];
     (*myVarNCData)->dimIDs[2] = clmIDs[4];
@@ -797,11 +797,11 @@ int LookUpCLMInventory(char * varName, varNCData **myVarNCData, int *clmIDs)
 
   if (strcmp(varName, "qflx_qirr_inst") == 0)
   {
-    *myVarNCData = malloc(sizeof(varNCData));
+    *myVarNCData = (varNCData*)malloc(sizeof(varNCData));
     (*myVarNCData)->varName = varName;
     (*myVarNCData)->ncType = NC_DOUBLE;
     (*myVarNCData)->dimSize = 4;
-    (*myVarNCData)->dimIDs = malloc((*myVarNCData)->dimSize * sizeof(int));
+    (*myVarNCData)->dimIDs = (int*)malloc((*myVarNCData)->dimSize * sizeof(int));
     (*myVarNCData)->dimIDs[0] = clmIDs[1];
     (*myVarNCData)->dimIDs[1] = clmIDs[2];
     (*myVarNCData)->dimIDs[2] = clmIDs[3];

--- a/pfsimulator/parflow_lib/write_parflow_netcdf.c
+++ b/pfsimulator/parflow_lib/write_parflow_netcdf.c
@@ -406,11 +406,11 @@ int LookUpInventory(char * varName, varNCData **myVarNCData, int *netCDFIDs)
 
   if (strcmp(varName, "time") == 0)
   {
-    *myVarNCData = malloc(sizeof(varNCData));
+    *myVarNCData = (varNCData*)malloc(sizeof(varNCData));
     (*myVarNCData)->varName = varName;
     (*myVarNCData)->ncType = NC_DOUBLE;
     (*myVarNCData)->dimSize = 1;
-    (*myVarNCData)->dimIDs = malloc((*myVarNCData)->dimSize * sizeof(int));
+    (*myVarNCData)->dimIDs = (int*)malloc((*myVarNCData)->dimSize * sizeof(int));
     (*myVarNCData)->dimIDs[0] = netCDFIDs[1];
     int timVarID;
     int res = nc_def_var(netCDFIDs[0], varName, (*myVarNCData)->ncType, (*myVarNCData)->dimSize,
@@ -425,11 +425,11 @@ int LookUpInventory(char * varName, varNCData **myVarNCData, int *netCDFIDs)
   }
   if (strcmp(varName, "pressure") == 0)
   {
-    *myVarNCData = malloc(sizeof(varNCData));
+    *myVarNCData = (varNCData*)malloc(sizeof(varNCData));
     (*myVarNCData)->varName = varName;
     (*myVarNCData)->ncType = NC_DOUBLE;
     (*myVarNCData)->dimSize = 4;
-    (*myVarNCData)->dimIDs = malloc((*myVarNCData)->dimSize * sizeof(int));
+    (*myVarNCData)->dimIDs = (int*)malloc((*myVarNCData)->dimSize * sizeof(int));
     (*myVarNCData)->dimIDs[0] = netCDFIDs[1];
     (*myVarNCData)->dimIDs[1] = netCDFIDs[2];
     (*myVarNCData)->dimIDs[2] = netCDFIDs[3];
@@ -467,11 +467,11 @@ int LookUpInventory(char * varName, varNCData **myVarNCData, int *netCDFIDs)
 
   if (strcmp(varName, "saturation") == 0)
   {
-    *myVarNCData = malloc(sizeof(varNCData));
+    *myVarNCData = (varNCData*)malloc(sizeof(varNCData));
     (*myVarNCData)->varName = varName;
     (*myVarNCData)->ncType = NC_DOUBLE;
     (*myVarNCData)->dimSize = 4;
-    (*myVarNCData)->dimIDs = malloc((*myVarNCData)->dimSize * sizeof(int));
+    (*myVarNCData)->dimIDs = (int*)malloc((*myVarNCData)->dimSize * sizeof(int));
     (*myVarNCData)->dimIDs[0] = netCDFIDs[1];
     (*myVarNCData)->dimIDs[1] = netCDFIDs[2];
     (*myVarNCData)->dimIDs[2] = netCDFIDs[3];
@@ -509,11 +509,11 @@ int LookUpInventory(char * varName, varNCData **myVarNCData, int *netCDFIDs)
 
   if (strcmp(varName, "mask") == 0)
   {
-    *myVarNCData = malloc(sizeof(varNCData));
+    *myVarNCData = (varNCData*)malloc(sizeof(varNCData));
     (*myVarNCData)->varName = varName;
     (*myVarNCData)->ncType = NC_DOUBLE;
     (*myVarNCData)->dimSize = 4;
-    (*myVarNCData)->dimIDs = malloc((*myVarNCData)->dimSize * sizeof(int));
+    (*myVarNCData)->dimIDs = (int*)malloc((*myVarNCData)->dimSize * sizeof(int));
     (*myVarNCData)->dimIDs[0] = netCDFIDs[1];
     (*myVarNCData)->dimIDs[1] = netCDFIDs[2];
     (*myVarNCData)->dimIDs[2] = netCDFIDs[3];
@@ -551,11 +551,11 @@ int LookUpInventory(char * varName, varNCData **myVarNCData, int *netCDFIDs)
 
   if (strcmp(varName, "mannings") == 0)
   {
-    *myVarNCData = malloc(sizeof(varNCData));
+    *myVarNCData = (varNCData*)malloc(sizeof(varNCData));
     (*myVarNCData)->varName = varName;
     (*myVarNCData)->ncType = NC_DOUBLE;
     (*myVarNCData)->dimSize = 3;
-    (*myVarNCData)->dimIDs = malloc((*myVarNCData)->dimSize * sizeof(int));
+    (*myVarNCData)->dimIDs = (int*)malloc((*myVarNCData)->dimSize * sizeof(int));
     (*myVarNCData)->dimIDs[0] = netCDFIDs[1];
     (*myVarNCData)->dimIDs[1] = netCDFIDs[3];
     (*myVarNCData)->dimIDs[2] = netCDFIDs[4];
@@ -591,11 +591,11 @@ int LookUpInventory(char * varName, varNCData **myVarNCData, int *netCDFIDs)
 
   if (strcmp(varName, "perm_x") == 0)
   {
-    *myVarNCData = malloc(sizeof(varNCData));
+    *myVarNCData = (varNCData*)malloc(sizeof(varNCData));
     (*myVarNCData)->varName = varName;
     (*myVarNCData)->ncType = NC_DOUBLE;
     (*myVarNCData)->dimSize = 4;
-    (*myVarNCData)->dimIDs = malloc((*myVarNCData)->dimSize * sizeof(int));
+    (*myVarNCData)->dimIDs = (int*)malloc((*myVarNCData)->dimSize * sizeof(int));
     (*myVarNCData)->dimIDs[0] = netCDFIDs[1];
     (*myVarNCData)->dimIDs[1] = netCDFIDs[2];
     (*myVarNCData)->dimIDs[2] = netCDFIDs[3];
@@ -633,11 +633,11 @@ int LookUpInventory(char * varName, varNCData **myVarNCData, int *netCDFIDs)
 
   if (strcmp(varName, "perm_y") == 0)
   {
-    *myVarNCData = malloc(sizeof(varNCData));
+    *myVarNCData = (varNCData*)malloc(sizeof(varNCData));
     (*myVarNCData)->varName = varName;
     (*myVarNCData)->ncType = NC_DOUBLE;
     (*myVarNCData)->dimSize = 4;
-    (*myVarNCData)->dimIDs = malloc((*myVarNCData)->dimSize * sizeof(int));
+    (*myVarNCData)->dimIDs = (int*)malloc((*myVarNCData)->dimSize * sizeof(int));
     (*myVarNCData)->dimIDs[0] = netCDFIDs[1];
     (*myVarNCData)->dimIDs[1] = netCDFIDs[2];
     (*myVarNCData)->dimIDs[2] = netCDFIDs[3];
@@ -675,11 +675,11 @@ int LookUpInventory(char * varName, varNCData **myVarNCData, int *netCDFIDs)
 
   if (strcmp(varName, "perm_z") == 0)
   {
-    *myVarNCData = malloc(sizeof(varNCData));
+    *myVarNCData = (varNCData*)malloc(sizeof(varNCData));
     (*myVarNCData)->varName = varName;
     (*myVarNCData)->ncType = NC_DOUBLE;
     (*myVarNCData)->dimSize = 4;
-    (*myVarNCData)->dimIDs = malloc((*myVarNCData)->dimSize * sizeof(int));
+    (*myVarNCData)->dimIDs = (int*)malloc((*myVarNCData)->dimSize * sizeof(int));
     (*myVarNCData)->dimIDs[0] = netCDFIDs[1];
     (*myVarNCData)->dimIDs[1] = netCDFIDs[2];
     (*myVarNCData)->dimIDs[2] = netCDFIDs[3];
@@ -717,11 +717,11 @@ int LookUpInventory(char * varName, varNCData **myVarNCData, int *netCDFIDs)
 
   if (strcmp(varName, "porosity") == 0)
   {
-    *myVarNCData = malloc(sizeof(varNCData));
+    *myVarNCData = (varNCData*)malloc(sizeof(varNCData));
     (*myVarNCData)->varName = varName;
     (*myVarNCData)->ncType = NC_DOUBLE;
     (*myVarNCData)->dimSize = 4;
-    (*myVarNCData)->dimIDs = malloc((*myVarNCData)->dimSize * sizeof(int));
+    (*myVarNCData)->dimIDs = (int*)malloc((*myVarNCData)->dimSize * sizeof(int));
     (*myVarNCData)->dimIDs[0] = netCDFIDs[1];
     (*myVarNCData)->dimIDs[1] = netCDFIDs[2];
     (*myVarNCData)->dimIDs[2] = netCDFIDs[3];
@@ -759,11 +759,11 @@ int LookUpInventory(char * varName, varNCData **myVarNCData, int *netCDFIDs)
 
   if (strcmp(varName, "specific_storage") == 0)
   {
-    *myVarNCData = malloc(sizeof(varNCData));
+    *myVarNCData = (varNCData*)malloc(sizeof(varNCData));
     (*myVarNCData)->varName = varName;
     (*myVarNCData)->ncType = NC_DOUBLE;
     (*myVarNCData)->dimSize = 4;
-    (*myVarNCData)->dimIDs = malloc((*myVarNCData)->dimSize * sizeof(int));
+    (*myVarNCData)->dimIDs = (int*)malloc((*myVarNCData)->dimSize * sizeof(int));
     (*myVarNCData)->dimIDs[0] = netCDFIDs[1];
     (*myVarNCData)->dimIDs[1] = netCDFIDs[2];
     (*myVarNCData)->dimIDs[2] = netCDFIDs[3];
@@ -801,11 +801,11 @@ int LookUpInventory(char * varName, varNCData **myVarNCData, int *netCDFIDs)
 
   if (strcmp(varName, "slopex") == 0)
   {
-    *myVarNCData = malloc(sizeof(varNCData));
+    *myVarNCData = (varNCData*)malloc(sizeof(varNCData));
     (*myVarNCData)->varName = varName;
     (*myVarNCData)->ncType = NC_DOUBLE;
     (*myVarNCData)->dimSize = 3;
-    (*myVarNCData)->dimIDs = malloc((*myVarNCData)->dimSize * sizeof(int));
+    (*myVarNCData)->dimIDs = (int*)malloc((*myVarNCData)->dimSize * sizeof(int));
     (*myVarNCData)->dimIDs[0] = netCDFIDs[1];
     (*myVarNCData)->dimIDs[1] = netCDFIDs[3];
     (*myVarNCData)->dimIDs[2] = netCDFIDs[4];
@@ -840,11 +840,11 @@ int LookUpInventory(char * varName, varNCData **myVarNCData, int *netCDFIDs)
   }
   if (strcmp(varName, "slopey") == 0)
   {
-    *myVarNCData = malloc(sizeof(varNCData));
+    *myVarNCData = (varNCData*)malloc(sizeof(varNCData));
     (*myVarNCData)->varName = varName;
     (*myVarNCData)->ncType = NC_DOUBLE;
     (*myVarNCData)->dimSize = 3;
-    (*myVarNCData)->dimIDs = malloc((*myVarNCData)->dimSize * sizeof(int));
+    (*myVarNCData)->dimIDs = (int*)malloc((*myVarNCData)->dimSize * sizeof(int));
     (*myVarNCData)->dimIDs[0] = netCDFIDs[1];
     (*myVarNCData)->dimIDs[1] = netCDFIDs[3];
     (*myVarNCData)->dimIDs[2] = netCDFIDs[4];
@@ -879,11 +879,11 @@ int LookUpInventory(char * varName, varNCData **myVarNCData, int *netCDFIDs)
   }
   if (strcmp(varName, "DZ_Multiplier") == 0)
   {
-    *myVarNCData = malloc(sizeof(varNCData));
+    *myVarNCData = (varNCData*)malloc(sizeof(varNCData));
     (*myVarNCData)->varName = varName;
     (*myVarNCData)->ncType = NC_DOUBLE;
     (*myVarNCData)->dimSize = 4;
-    (*myVarNCData)->dimIDs = malloc((*myVarNCData)->dimSize * sizeof(int));
+    (*myVarNCData)->dimIDs = (int*)malloc((*myVarNCData)->dimSize * sizeof(int));
     (*myVarNCData)->dimIDs[0] = netCDFIDs[1];
     (*myVarNCData)->dimIDs[1] = netCDFIDs[2];
     (*myVarNCData)->dimIDs[2] = netCDFIDs[3];
@@ -921,11 +921,11 @@ int LookUpInventory(char * varName, varNCData **myVarNCData, int *netCDFIDs)
 
   if (strcmp(varName, "evaptrans") == 0)
   {
-    *myVarNCData = malloc(sizeof(varNCData));
+    *myVarNCData = (varNCData*)malloc(sizeof(varNCData));
     (*myVarNCData)->varName = varName;
     (*myVarNCData)->ncType = NC_DOUBLE;
     (*myVarNCData)->dimSize = 4;
-    (*myVarNCData)->dimIDs = malloc((*myVarNCData)->dimSize * sizeof(int));
+    (*myVarNCData)->dimIDs = (int*)malloc((*myVarNCData)->dimSize * sizeof(int));
     (*myVarNCData)->dimIDs[0] = netCDFIDs[1];
     (*myVarNCData)->dimIDs[1] = netCDFIDs[2];
     (*myVarNCData)->dimIDs[2] = netCDFIDs[3];
@@ -963,11 +963,11 @@ int LookUpInventory(char * varName, varNCData **myVarNCData, int *netCDFIDs)
 
   if (strcmp(varName, "evaptrans_sum") == 0)
   {
-    *myVarNCData = malloc(sizeof(varNCData));
+    *myVarNCData = (varNCData*)malloc(sizeof(varNCData));
     (*myVarNCData)->varName = varName;
     (*myVarNCData)->ncType = NC_DOUBLE;
     (*myVarNCData)->dimSize = 4;
-    (*myVarNCData)->dimIDs = malloc((*myVarNCData)->dimSize * sizeof(int));
+    (*myVarNCData)->dimIDs = (int*)malloc((*myVarNCData)->dimSize * sizeof(int));
     (*myVarNCData)->dimIDs[0] = netCDFIDs[1];
     (*myVarNCData)->dimIDs[1] = netCDFIDs[2];
     (*myVarNCData)->dimIDs[2] = netCDFIDs[3];
@@ -1004,11 +1004,11 @@ int LookUpInventory(char * varName, varNCData **myVarNCData, int *netCDFIDs)
   }
   if (strcmp(varName, "overland_sum") == 0)
   {
-    *myVarNCData = malloc(sizeof(varNCData));
+    *myVarNCData = (varNCData*)malloc(sizeof(varNCData));
     (*myVarNCData)->varName = varName;
     (*myVarNCData)->ncType = NC_DOUBLE;
     (*myVarNCData)->dimSize = 3;
-    (*myVarNCData)->dimIDs = malloc((*myVarNCData)->dimSize * sizeof(int));
+    (*myVarNCData)->dimIDs = (int*)malloc((*myVarNCData)->dimSize * sizeof(int));
     (*myVarNCData)->dimIDs[0] = netCDFIDs[1];
     (*myVarNCData)->dimIDs[1] = netCDFIDs[3];
     (*myVarNCData)->dimIDs[2] = netCDFIDs[4];
@@ -1044,11 +1044,11 @@ int LookUpInventory(char * varName, varNCData **myVarNCData, int *netCDFIDs)
 
   if (strcmp(varName, "overland_bc_flux") == 0)
   {
-    *myVarNCData = malloc(sizeof(varNCData));
+    *myVarNCData = (varNCData*)malloc(sizeof(varNCData));
     (*myVarNCData)->varName = varName;
     (*myVarNCData)->ncType = NC_DOUBLE;
     (*myVarNCData)->dimSize = 3;
-    (*myVarNCData)->dimIDs = malloc((*myVarNCData)->dimSize * sizeof(int));
+    (*myVarNCData)->dimIDs = (int*)malloc((*myVarNCData)->dimSize * sizeof(int));
     (*myVarNCData)->dimIDs[0] = netCDFIDs[1];
     (*myVarNCData)->dimIDs[1] = netCDFIDs[3];
     (*myVarNCData)->dimIDs[2] = netCDFIDs[4];


### PR DESCRIPTION
CMake flag added to enable compiling ParFlow as C++.
Minor changes to fix minor C++ compatibility issues.