### PR TITLE
Update artifact actions

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -10,13 +10,6 @@ jobs:
        - name: Checkout commit
          uses: actions/checkout@v4
 
-       - name: Package Install
-         uses: awalsh128/cache-apt-pkgs-action@latest
-         with:
-           packages: curl cmake build-essential tcl-dev tk-dev
-           version: 1.0
-           execute_install_scripts: true
-
        - name: Cache dependencies
          uses: actions/cache@v4
          id: cache-parflow-style-dependencies
@@ -183,13 +176,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-
-    - name: Package Install
-      uses: awalsh128/cache-apt-pkgs-action@latest
-      with:
-        packages: gfortran hdf5-helpers tcl-dev tk-dev libcurl4 libcurl4-gnutls-dev
-        version: 1.0
-        execute_install_scripts: true
 
     - name: HDF5 and OpenMPI Install on Ubuntu 22.04
       if: matrix.config.os == 'ubuntu-20.04' || matrix.config.os == 'ubuntu-22.04'

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -10,6 +10,11 @@ jobs:
        - name: Checkout commit
          uses: actions/checkout@v4
 
+       - name: Package Install
+         run: |
+           sudo apt-get -qq update
+           sudo apt-get -qq install curl cmake build-essential tcl-dev tk-dev
+
        - name: Cache dependencies
          uses: actions/cache@v4
          id: cache-parflow-style-dependencies
@@ -176,6 +181,11 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+
+    - name: Package Install
+      run: |
+        sudo apt-get -qq update
+        sudo apt-get -qq install curl cmake build-essential tcl-dev tk-dev gfortran hdf5-helpers libcurl4 libcurl4-gnutls-dev
 
     - name: HDF5 and OpenMPI Install on Ubuntu 22.04
       if: matrix.config.os == 'ubuntu-20.04' || matrix.config.os == 'ubuntu-22.04'


### PR DESCRIPTION
Remove third party action that was broken.   The awalsh128/cache-apt-pkgs-action package looks to be unsupported and does not work with recent GitHub changes.