### PR TITLE
Feature/mixed surface bcs

### DIFF
--- a/docs/user_manual/keys.rst
+++ b/docs/user_manual/keys.rst
@@ -4452,6 +4452,42 @@ minimum value for the :math:`\bar{S_{f}}` used in the
    pfset Solver.OverlandKinematic.Epsilon 1E-7           ## TCL syntax
 
    <runname>.Solver.OverlandKinematic.Epsilon = 1E-7     ## Python syntax
+  
+
+Mixed Boundary Conditions  
+
+If the top boundary is set to **OverlandKinematic** and a pfsolid file is used, this solid file can have multiple patches with mixed boundary conditions.  One patch is assigned to the overland kinematic, and up to two more patches can be assigned to seepage face cells mixed in with the overland flow.
+
+*double* **Solver.OverlandKinematic.SeepageOne** -999  
+
+This key sets the first of two available patch values for mixed boundary conditions.
+
+::
+   pfset Solver.OverlandKinematic.SeepageOne 3           ## TCL syntax
+
+   <runname>.Solver.OverlandKinematic.SeepageOne = 3    ## Python syntax
+
+*double* **Solver.OverlandKinematic.SeepageTwo** -999 This key sets the second of two available patch values for mixed boundary conditions.
+
+::
+
+   pfset Solver.OverlandKinematic.SeepageTwo 4           ## TCL syntax
+
+   <runname>.Solver.OverlandKinematic.SeepageTwo = 4    ## Python syntax
+
+Example of mixed boundary conditions: 
+
+::
+   CONUS2.Geom.domain.Patches = "ocean land top lake sink bottom"
+   CONUS2.BCPressure.PatchNames ="ocean land top lake sink bottom"
+
+In this example, the top gets assigned to the **OverlandKinematic** BC (below) and the sink and bottom (patch 3 and patch 4 starting from zero) get assigned **SeepageFace**.
+ 
+::
+   
+   CONUS2.Patch.top.BCPressure.Type = 'OverlandKinematic'
+   CONUS2.Solver.OverlandKinematic.SeepageOne = 3  
+   CONUS2.Solver.OverlandKinematic.SeepageTwo = 4 
 
 
 *string* **Solver.PrintInitialConditions** True This key is used to

--- a/pf-keys/definitions/solver.yaml
+++ b/pf-keys/definitions/solver.yaml
@@ -1669,6 +1669,16 @@ Solver:
         DoubleValue:
           min_value: 0.0
 
+    SeepageOne:
+      help: >
+        [Type: double] This key sets a patch value for a mixed seepage face boundary condition.
+      default: -999
+
+    SeepageTwo:
+      help: >
+        [Type: double] This key sets a patch value for a mixed seepage face boundary condition.
+      default: -999
+
   # missing from manual
   PolyDegree:
     help: >

--- a/pfsimulator/parflow_lib/nl_function_eval.c
+++ b/pfsimulator/parflow_lib/nl_function_eval.c
@@ -41,6 +41,8 @@ typedef struct {
   double SpinupDampP1;      // NBE
   double SpinupDampP2;      // NBE
   int tfgupwind;           //@RMM added for TFG formulation switch
+  int seepage_patch_one;  //RMM added two optional seepage face BCs
+  int seepage_patch_two; 
 } PublicXtra;
 
 typedef struct {
@@ -182,6 +184,10 @@ void NlFunctionEval(Vector *     pressure, /* Current pressure values */
   Subvector   *FBx_sub, *FBy_sub, *FBz_sub;  //@RMM
   double      *FBx_dat = NULL, *FBy_dat = NULL, *FBz_dat = NULL;   //@RMM
 
+/* RMM Top patch indicator for multiple / combined overland BC */
+  Vector      *patch = ProblemDataPatchIndexOfDomainTop(problem_data);
+  Subvector   *patch_sub;
+  double      *patch_dat=NULL;
 
   double gravity = ProblemGravity(problem);
   double viscosity = ProblemPhaseViscosity(problem, 0);
@@ -283,6 +289,10 @@ void NlFunctionEval(Vector *     pressure, /* Current pressure values */
     FBx_sub = VectorSubvector(FBx, is);
     FBy_sub = VectorSubvector(FBy, is);
     FBz_sub = VectorSubvector(FBz, is);
+
+    /* RMM added to provide patch access */
+    patch_sub = VectorSubvector(patch, is);
+    patch_dat = SubvectorData(patch_sub);
 
     /* @RMM added to provide FB values */
     FBx_dat = SubvectorData(FBx_sub);
@@ -568,6 +578,10 @@ void NlFunctionEval(Vector *     pressure, /* Current pressure values */
     /* @RMM added to provide access to zmult */
     z_mult_sub = VectorSubvector(z_mult, is);
 
+    /* RMM added to provide patch access */
+    patch_sub = VectorSubvector(patch, is);
+    patch_dat = SubvectorData(patch_sub);
+
     /* RDF: assumes resolutions are the same in all 3 directions */
     r = SubgridRX(subgrid);
 
@@ -800,6 +814,10 @@ void NlFunctionEval(Vector *     pressure, /* Current pressure values */
     /* @RMM added to provide access to x/y slopes */
     x_ssl_sub = VectorSubvector(x_ssl, is);
     y_ssl_sub = VectorSubvector(y_ssl, is);
+
+    /* RMM added to provide patch access */
+    patch_sub = VectorSubvector(patch, is);
+    patch_dat = SubvectorData(patch_sub);
 
     // sk Overland flow
     kw_sub = VectorSubvector(KW, is);
@@ -1884,10 +1902,21 @@ void NlFunctionEval(Vector *     pressure, /* Current pressure values */
         u_new = h;
 
         q_overlnd = 0.0;
+        // RMM, switch seepage face on optionally for two surface patches
+        if ((int)patch_dat[io] == public_xtra->seepage_patch_one || (int)patch_dat[io] == public_xtra->seepage_patch_two) {
+          q_overlnd = vol
+                    * (pfmax(pp[ip], 0.0) -0.0) / dz; //+
+                    //* dt* (pfmax(pp[ip], 0.0) -0.0) / dz + //RMM, why is dt multiplied by the first term?
+                   // dt * vol * ((ke_[io] - kw_[io]) / dx + (kn_[io] - ks_[io]) / dy)
+                   // / dz;
+          //printf("Current Patch %d, seepage one %d, %d (%d,%d,%d)\n",(int)patch_dat[io], public_xtra->seepage_patch_one, io, i,j,k);
+        } else {
         q_overlnd = vol
                     * (pfmax(pp[ip], 0.0) - pfmax(opp[ip], 0.0)) / dz +
                     dt * vol * ((ke_[io] - kw_[io]) / dx + (kn_[io] - ks_[io]) / dy)
                     / dz;
+        }
+        
         fp[ip] += q_overlnd;
       }),
                            CellFinalize(
@@ -2327,6 +2356,11 @@ PFModule   *NlFunctionEvalNewPublicXtra(char *name)
   public_xtra->SpinupDampP1 = GetDoubleDefault(key, 0.0);
   sprintf(key, "OverlandSpinupDampP2");
   public_xtra->SpinupDampP2 = GetDoubleDefault(key, 0.0);    //NBE
+
+  sprintf(key, "Solver.OverlandKinematic.SeepageOne");
+  public_xtra->seepage_patch_one = GetDoubleDefault(key, -999);
+  sprintf(key, "Solver.OverlandKinematic.SeepageTwo");
+  public_xtra->seepage_patch_two = GetDoubleDefault(key, -999);
 
   ///* parameters for upwinding formulation for TFG */
   upwind_switch_na = NA_NewNameArray("Original UpwindSine Upwind");

--- a/pfsimulator/parflow_lib/overlandflow_eval_Kin.c
+++ b/pfsimulator/parflow_lib/overlandflow_eval_Kin.c
@@ -83,10 +83,11 @@ void    OverlandFlowEvalKin(
   Vector      *slope_y = ProblemDataTSlopeY(problem_data);
   Vector      *mannings = ProblemDataMannings(problem_data);
   Vector      *top = ProblemDataIndexOfDomainTop(problem_data);
+  Vector      *patch = ProblemDataPatchIndexOfDomainTop(problem_data);
 
-  Subvector     *sx_sub, *sy_sub, *mann_sub, *top_sub, *p_sub;
+  Subvector     *sx_sub, *sy_sub, *mann_sub, *top_sub, *patch_sub, *p_sub;
 
-  double        *sx_dat, *sy_dat, *mann_dat, *top_dat, *pp;
+  double        *sx_dat, *sy_dat, *mann_dat, *top_dat, *patch_dat, *pp;
 
   double ov_epsilon;
 
@@ -100,6 +101,7 @@ void    OverlandFlowEvalKin(
   sy_sub = VectorSubvector(slope_y, sg);
   mann_sub = VectorSubvector(mannings, sg);
   top_sub = VectorSubvector(top, sg);
+  patch_sub = VectorSubvector(patch, sg);
 
   pp = SubvectorData(p_sub);
 
@@ -107,6 +109,7 @@ void    OverlandFlowEvalKin(
   sy_dat = SubvectorData(sy_sub);
   mann_dat = SubvectorData(mann_sub);
   top_dat = SubvectorData(top_sub);
+  patch_dat = SubvectorData(patch_sub);
 
   sy_v = SubvectorNX(top_sub);
 
@@ -119,8 +122,9 @@ void    OverlandFlowEvalKin(
     ForPatchCellsPerFaceWithGhost(BC_ALL,
                                   BeforeAllCells(DoNothing),
                                   LoopVars(i, j, k, ival, bc_struct, ipatch, sg),
-                                  Locals(int io, itop, ip, ipp1, ippsy;
+                                  Locals(int io, itop, ip, ipp1, ipm1, ipmsy, ippsy, ipat;
                                          int k1, k0x, k0y, k1x, k1y;
+                                         int p1, p0x, p0y;
                                          double Sf_x, Sf_y, Sf_mag;
                                          double Press_x, Press_y; ),
                                   CellSetup(DoNothing),
@@ -131,12 +135,20 @@ void    OverlandFlowEvalKin(
     {
       io = SubvectorEltIndex(sx_sub, i, j, 0);
       itop = SubvectorEltIndex(top_sub, i, j, 0);
+      ipat = SubvectorEltIndex(patch_sub, i, j, 0);
 
       k1 = (int)top_dat[itop];
       k0x = (int)top_dat[itop - 1];
       k0y = (int)top_dat[itop - sy_v];
       k1x = pfmax((int)top_dat[itop + 1], 0);
       k1y = pfmax((int)top_dat[itop + sy_v], 0);
+      //RMM added patches to check for internal bc edges
+      p1 = (int)patch_dat[ipat];
+      p0x = (int)patch_dat[ipat - 1];
+      p0y = (int)patch_dat[ipat - sy_v];
+      //printf("Current Patch %d, lower x %d, lower y %d, (%d,%d,%d)\n",p1, p0x, p0y, i,j,k);
+      //printf("Current top %d, lower x %d, lower y %d, (%d,%d,%d)\n",k1, k0x, k0y, i,j,k);
+
 
       if (k1 >= 0)
       {
@@ -162,6 +174,52 @@ void    OverlandFlowEvalKin(
         qy_v[io] = -(Sf_y / (RPowerR(fabs(Sf_mag), 0.5)
                              * mann_dat[io])) * RPowerR(Press_y, (5.0 / 3.0));
       }
+      // fix for internal patch edges in x direction
+      if (p1 != p0x) 
+      {
+        if (k1 >= 0)
+        {
+        ip = SubvectorEltIndex(p_sub, i, j, k1);
+        Sf_x = sx_dat[io-1];
+        Sf_y = sy_dat[io-1];
+        ipm1 = (int)SubvectorEltIndex(p_sub, i - 1, j, k1x);
+
+        Sf_mag = RPowerR(Sf_x * Sf_x + Sf_y * Sf_y, 0.5);
+        if (Sf_mag < ov_epsilon)
+          Sf_mag = ov_epsilon;
+
+        Press_x = RPMean(-Sf_x, 0.0,
+                         pfmax((pp[ipm1]), 0.0),
+                         pfmax((pp[ip]), 0.0));
+
+        qx_v[io-1] = -(Sf_x / (RPowerR(fabs(Sf_mag), 0.5) * mann_dat[io-1]))
+                   * RPowerR(Press_x, (5.0 / 3.0));
+
+        }
+      }
+
+      // fix for internal patch edges in y direction
+      if (p1 != p0y) 
+      {
+        if (k1 >= 0)
+        {
+        ip = SubvectorEltIndex(p_sub, i, j, k1);
+        Sf_x = sx_dat[io-sy_v];
+        Sf_y = sy_dat[io-sy_v];
+        ipmsy = (int)SubvectorEltIndex(p_sub, i, j - 1, k1y);
+
+        Sf_mag = RPowerR(Sf_x * Sf_x + Sf_y * Sf_y, 0.5);
+        if (Sf_mag < ov_epsilon)
+          Sf_mag = ov_epsilon;
+
+        Press_y = RPMean(-Sf_y, 0.0,
+                         pfmax((pp[ipmsy]), 0.0),
+                         pfmax((pp[ip]), 0.0));
+
+        qy_v[io-sy_v] = -(Sf_y / (RPowerR(fabs(Sf_mag), 0.5)
+                             * mann_dat[io-sy_v])) * RPowerR(Press_y, (5.0 / 3.0));
+        }
+      }
 
       //fix for lower x boundary
       if (k0x < 0.0)
@@ -185,7 +243,7 @@ void    OverlandFlowEvalKin(
       }
 
       //fix for lower y boundary
-      if (k0y < 0.0)
+      if (k0y < 0.0) 
       {
         if (k1 >= 0.0)
         {
@@ -232,26 +290,32 @@ void    OverlandFlowEvalKin(
   else          //fcn = CALCDER calculates the derivs
   {
     ForPatchCellsPerFaceWithGhost(BC_ALL,
-                                  BeforeAllCells(DoNothing),
-                                  LoopVars(i, j, k, ival, bc_struct, ipatch, sg),
-                                  Locals(int io, itop, ip, ipp1, ippsy;
-                                         int k1, k0x, k0y, k1x, k1y;
-                                         double Sf_x, Sf_y, Sf_mag;
-                                         double Press_x, Press_y, qx_temp, qy_temp; ),
-                                  CellSetup(DoNothing),
-                                  FACE(LeftFace, DoNothing), FACE(RightFace, DoNothing),
-                                  FACE(DownFace, DoNothing), FACE(UpFace, DoNothing),
-                                  FACE(BackFace, DoNothing),
-                                  FACE(FrontFace,
+                  BeforeAllCells(DoNothing),
+                  LoopVars(i, j, k, ival, bc_struct, ipatch, sg),
+                  Locals(int io, itop, ipat, ip, ipp1, ippsy, ipm1, ipmsy;
+                          int k1, k0x, k0y, k1x, k1y;
+                          int p1, p0x, p0y;
+                          double Sf_x, Sf_y, Sf_mag;
+                          double Press_x, Press_y, qx_temp, qy_temp; ),
+                  CellSetup(DoNothing),
+                  FACE(LeftFace, DoNothing), FACE(RightFace, DoNothing),
+                  FACE(DownFace, DoNothing), FACE(UpFace, DoNothing),
+                  FACE(BackFace, DoNothing),
+                  FACE(FrontFace,
     {
       io = SubvectorEltIndex(sx_sub, i, j, 0);
       itop = SubvectorEltIndex(top_sub, i, j, 0);
+      ipat = SubvectorEltIndex(patch_sub, i, j, 0);
 
       k1 = (int)top_dat[itop];
       k0x = (int)top_dat[itop - 1];
       k0y = (int)top_dat[itop - sy_v];
       k1x = (int)top_dat[itop + 1];
       k1y = (int)top_dat[itop + sy_v];
+      //RMM added patches to check for internal bc edges
+      p1 = (int)patch_dat[ipat];
+      p0x = (int)patch_dat[ipat - 1];
+      p0y = (int)patch_dat[ipat - sy_v];
 
       if (k1 >= 0)
       {
@@ -275,6 +339,15 @@ void    OverlandFlowEvalKin(
 
         qx_temp = -(5.0 / 3.0) * (Sf_x / (RPowerR(fabs(Sf_mag), 0.5) * mann_dat[io])) * RPowerR(Press_x, (2.0 / 3.0));
         qy_temp = -(5.0 / 3.0) * (Sf_y / (RPowerR(fabs(Sf_mag), 0.5) * mann_dat[io])) * RPowerR(Press_y, (2.0 / 3.0));
+        //ke_v[io] = qx_temp;
+        //kn_v[io] = qy_temp;
+        //kw_v[io+1] = qx_temp;
+        //ks_v[io+sy_v] = qy_temp;
+      
+      //ke_v[io] = qx_v[io];**
+      //kw_v[io] = qx_v[io - 1];
+      //kn_v[io] = qy_v[io];**
+      //ks_v[io] = qy_v[io - sy_v];
 
         ke_v[io] = pfmax(qx_temp, 0);
         kw_v[io + 1] = -pfmax(-qx_temp, 0);
@@ -282,8 +355,56 @@ void    OverlandFlowEvalKin(
         ks_v[io + sy_v] = -pfmax(-qy_temp, 0);
       }
 
+// fix for internal patch edges in x direction
+      if (p1 != p0x) 
+      {
+        if (k1 >= 0)
+        {
+        ip = SubvectorEltIndex(p_sub, i, j, k1);
+        Sf_x = sx_dat[io-1];
+        Sf_y = sy_dat[io-1];
+        ipm1 = (int)SubvectorEltIndex(p_sub, i - 1, j, k1x);
+
+        Sf_mag = RPowerR(Sf_x * Sf_x + Sf_y * Sf_y, 0.5);
+        if (Sf_mag < ov_epsilon)
+          Sf_mag = ov_epsilon;
+
+        Press_x = RPMean(-Sf_x, 0.0,
+                         pfmax((pp[ipm1]), 0.0),
+                         pfmax((pp[ip]), 0.0));
+
+       qx_temp = -(5.0 / 3.0) * (Sf_x / (RPowerR(fabs(Sf_mag), 0.5) * mann_dat[io-1])) * RPowerR(Press_x, (2.0 / 3.0));
+        kw_v[io] = -pfmax(-qx_temp,0);
+        ke_v[io - 1] = pfmax(qx_temp,0);        
+        }
+      }
+
+      // fix for internal patch edges in y direction
+      if (p1 != p0y) 
+      {
+        if (k1 >= 0)
+        {
+        ip = SubvectorEltIndex(p_sub, i, j, k1);
+        Sf_x = sx_dat[io-sy_v];
+        Sf_y = sy_dat[io-sy_v];
+        ipmsy = (int)SubvectorEltIndex(p_sub, i, j - 1, k1y);
+
+        Sf_mag = RPowerR(Sf_x * Sf_x + Sf_y * Sf_y, 0.5);
+        if (Sf_mag < ov_epsilon)
+          Sf_mag = ov_epsilon;
+
+        Press_y = RPMean(-Sf_y, 0.0,
+                         pfmax((pp[ipmsy]), 0.0),
+                         pfmax((pp[ip]), 0.0));
+
+        qy_temp = -(5.0 / 3.0) * (Sf_y / (RPowerR(fabs(Sf_mag), 0.5) * mann_dat[io-sy_v])) * RPowerR(Press_y, (2.0 / 3.0));
+        ks_v[io] = -pfmax(-qy_temp,0);
+        kn_v[io - sy_v] = pfmax(qy_temp,0);
+        }
+      }
+
       //fix for lower x boundary
-      if (k0x < 0.0)
+      if (k0x < 0.0) 
       {
         if (k1 >= 0.0)
         {
@@ -299,15 +420,18 @@ void    OverlandFlowEvalKin(
             ip = SubvectorEltIndex(p_sub, i, j, k1);
             Press_x = pfmax((pp[ip]), 0.0);
             qx_temp = -(5.0 / 3.0) * (Sf_x / (RPowerR(fabs(Sf_mag), 0.5) * mann_dat[io])) * RPowerR(Press_x, (2.0 / 3.0));
+            //qx_v[io - 1] = qx_temp;
 
-            kw_v[io] = qx_temp;
-            ke_v[io - 1] = qx_temp;
+            //kw_v[io] = qx_temp;
+            //ke_v[io - 1] = qx_temp;
+            kw_v[io] = -pfmax(-qx_temp,0);
+            ke_v[io - 1] = pfmax(qx_temp,0);
           }
         }
       }
 
       //fix for lower y boundary
-      if (k0y < 0.0)
+      if (k0y < 0.0) 
       {
         if (k1 >= 0.0)
         {
@@ -323,16 +447,38 @@ void    OverlandFlowEvalKin(
             ip = SubvectorEltIndex(p_sub, i, j, k1);
             Press_y = pfmax((pp[ip]), 0.0);
             qy_temp = -(5.0 / 3.0) * (Sf_y / (RPowerR(fabs(Sf_mag), 0.5) * mann_dat[io])) * RPowerR(Press_y, (2.0 / 3.0));
-
-            ks_v[io] = qy_temp;
-            kn_v[io - sy_v] = qy_temp;
+            //qy_v[io - sy_v] = qy_temp;
+            //ks_v[io] = qy_temp;
+            ks_v[io] = -pfmax(-qy_temp,0);
+            //kn_v[io - sy_v] = qy_temp;
+            kn_v[io - sy_v] = pfmax(qy_temp,0);
+            
           }
         }
       }
     }),
-                                  CellFinalize(DoNothing),
-                                  AfterAllCells(DoNothing)
-                                  );
+          CellFinalize(DoNothing),
+          AfterAllCells(DoNothing)
+          );
+          /*                        ForPatchCellsPerFace(BC_ALL,
+                         BeforeAllCells(DoNothing),
+                         LoopVars(i, j, k, ival, bc_struct, ipatch, sg),
+                         Locals(int io; ),
+                         CellSetup(DoNothing),
+                         FACE(LeftFace, DoNothing), FACE(RightFace, DoNothing),
+                         FACE(DownFace, DoNothing), FACE(UpFace, DoNothing),
+                         FACE(BackFace, DoNothing),
+                         FACE(FrontFace,
+    {
+      io = SubvectorEltIndex(sx_sub, i, j, 0);
+      ke_v[io] = qx_v[io];
+      kw_v[io] = qx_v[io - 1];
+      kn_v[io] = qy_v[io];
+      ks_v[io] = qy_v[io - sy_v];
+    }),
+                         CellFinalize(DoNothing),
+                         AfterAllCells(DoNothing)
+                         ); */
   }   // else calcder
 }     // function
 

--- a/pfsimulator/parflow_lib/richards_jacobian_eval.c
+++ b/pfsimulator/parflow_lib/richards_jacobian_eval.c
@@ -63,6 +63,8 @@ typedef struct {
   double SpinupDampP2; // NBE
   int tfgupwind;  // RMM
   int using_MGSemi;  // RMM
+  int seepage_patch_one;  //RMM added two optional seepage face BCs
+  int seepage_patch_two;
 } PublicXtra;
 
 typedef struct {
@@ -250,18 +252,22 @@ void    RichardsJacobianEval(
   Subvector   *x_ssl_sub, *y_ssl_sub;    //@RMM
   double      *x_ssl_dat = NULL, *y_ssl_dat = NULL;     //@RMM
 
-  /* @RMM variable dz multiplier */
+  /* RMM variable dz multiplier */
   Vector      *z_mult = ProblemDataZmult(problem_data);              //@RMM
   Subvector   *z_mult_sub;    //@RMM
   double      *z_mult_dat;    //@RMM
 
-  /* @RMM Flow Barrier / Boundary values */
+  /* RMM Flow Barrier / Boundary values */
   Vector      *FBx = ProblemDataFBx(problem_data);
   Vector      *FBy = ProblemDataFBy(problem_data);
   Vector      *FBz = ProblemDataFBz(problem_data);
   Subvector   *FBx_sub, *FBy_sub, *FBz_sub;    //@RMM
   double      *FBx_dat, *FBy_dat, *FBz_dat;     //@RMM
 
+/* RMM Top patch indicator for multiple  combined overland BC */
+  Vector      *patch = ProblemDataPatchIndexOfDomainTop(problem_data);
+  Subvector   *patch_sub;
+  double      *patch_dat;
   Subgrid     *subgrid;
 
   Subvector   *p_sub, *d_sub, *s_sub, *po_sub, *rp_sub, *ss_sub;
@@ -1497,6 +1503,8 @@ void    RichardsJacobianEval(
       kens_sub = VectorSubvector(KEns, is);
       knns_sub = VectorSubvector(KNns, is);
       ksns_sub = VectorSubvector(KSns, is);
+      /* RMM added to provide patch access */
+      patch_sub = VectorSubvector(patch, is);
 
       top_sub = VectorSubvector(top, is);
       sx_sub = VectorSubvector(slope_x, is);
@@ -1541,13 +1549,14 @@ void    RichardsJacobianEval(
       ksns_der = SubvectorData(ksns_sub);
 
       top_dat = SubvectorData(top_sub);
+      patch_dat = SubvectorData(patch_sub);
 
       ForBCStructNumPatches(ipatch, bc_struct)
       {
         ForPatchCellsPerFace(OverlandKinematicBC,
                              BeforeAllCells(DoNothing),
                              LoopVars(i, j, k, ival, bc_struct, ipatch, is),
-                             Locals(int io, io1, itop, ip, im, k1; ),
+                             Locals(int io, io1, itop, ip, im, iitmp, ione,itwo, k1; ),
                              CellSetup(DoNothing),
                              FACE(LeftFace, DoNothing), FACE(RightFace, DoNothing),
                              FACE(DownFace, DoNothing), FACE(UpFace, DoNothing),
@@ -1609,12 +1618,23 @@ void    RichardsJacobianEval(
             }
           }
 
+          iitmp = (int)patch_dat[io1];
+          ione = public_xtra->seepage_patch_one;
+          itwo = public_xtra->seepage_patch_two;
+
           /* Now add overland contributions to JC */
           if ((pp[ip]) > 0.0)
           {
-            /*diagonal term */
-            cp_c[io] += (vol / dz) + (vol / ffy) * dt * (ke_der[io1] - kw_der[io1])
+              /* RMM, switch seepage face on optionally for two surface patches */
+              if ( iitmp == ione || iitmp == itwo )  {
+              cp_c[io] += (vol / dz)  * (1.0 + 0.0); // + (vol / ffy) * dt * (ke_der[io1] - kw_der[io1])
+             //           + (vol / ffx) * dt * (kn_der[io1] - ks_der[io1]);
+             // printf("Seepage face on: Current Patch %d, seepage one %d, %d (%d,%d,%d)\n",(int)patch_dat[io], public_xtra->seepage_patch_one, io, i,j,k);
+              } else {
+              /*regular overland diagonal term */
+              cp_c[io] += (vol / dz) + (vol / ffy) * dt * (ke_der[io1] - kw_der[io1])
                         + (vol / ffx) * dt * (kn_der[io1] - ks_der[io1]);
+              }
           }
 
           /*west term */
@@ -1879,6 +1899,8 @@ void    RichardsJacobianEval(
       kens_sub = VectorSubvector(KEns, is);
       knns_sub = VectorSubvector(KNns, is);
       ksns_sub = VectorSubvector(KSns, is);
+      /* RMM added to provide patch access */
+      patch_sub = VectorSubvector(patch, is);
 
       top_sub = VectorSubvector(top, is);
       sx_sub = VectorSubvector(slope_x, is);
@@ -1916,13 +1938,14 @@ void    RichardsJacobianEval(
       ksns_der = SubvectorData(ksns_sub);
 
       top_dat = SubvectorData(top_sub);
+      patch_dat = SubvectorData(patch_sub);
 
       ForBCStructNumPatches(ipatch, bc_struct)
       {
         ForPatchCellsPerFace(OverlandKinematicBC,
                              BeforeAllCells(DoNothing),
                              LoopVars(i, j, k, ival, bc_struct, ipatch, is),
-                             Locals(int io1, ip, im; ),
+                             Locals(int io1, ip, itop, im, iitmp, ione, itwo; ),
                              CellSetup(DoNothing),
                              FACE(LeftFace, DoNothing), FACE(RightFace, DoNothing),
                              FACE(DownFace, DoNothing), FACE(UpFace, DoNothing),
@@ -1931,17 +1954,28 @@ void    RichardsJacobianEval(
         {
           /* Loop over boundary patches to build J matrix. */
           io1 = SubvectorEltIndex(sx_sub, i, j, 0);
+          itop = SubvectorEltIndex(top_sub, i, j, 0);
 
           /* Update J */
           ip = SubvectorEltIndex(p_sub, i, j, k);
           im = SubmatrixEltIndex(J_sub, i, j, k);
 
+          iitmp = (int)patch_dat[itop];
+          ione = public_xtra->seepage_patch_one;
+          itwo = public_xtra->seepage_patch_two;
+
           /* Now add overland contributions to J similar to JC above */
           if ((pp[ip]) > 0.0)
           {
-            /*diagonal term */
-            cp[im] += (vol / dz) + (vol / ffy) * dt * (ke_der[io1] - kw_der[io1])
-                      + (vol / ffx) * dt * (kn_der[io1] - ks_der[io1]);
+            /* RMM, switch seepage face on optionally for two surface patches */
+            if ( iitmp == ione || iitmp == itwo )  {
+            cp[im] += dt*(vol / dz)  * (1.0 + 0.0); // + (vol / ffy) * dt * (ke_der[io1] - kw_der[io1])
+                    //  + (vol / ffx) * dt * (kn_der[io1] - ks_der[io1]);
+            } else {
+              /*diagonal term */
+              cp[im] += (vol / dz) + (vol / ffy) * dt * (ke_der[io1] - kw_der[io1])
+                        + (vol / ffx) * dt * (kn_der[io1] - ks_der[io1]);
+            }
           }
 
           /*west term */
@@ -2345,6 +2379,12 @@ PFModule   *RichardsJacobianEvalNewPublicXtra(char *name)
   public_xtra->SpinupDampP1 = GetDoubleDefault(key, 0.0);
   sprintf(key, "OverlandSpinupDampP2");
   public_xtra->SpinupDampP2 = GetDoubleDefault(key, 0.0);    // NBE
+
+  sprintf(key, "Solver.OverlandKinematic.SeepageOne");
+  public_xtra->seepage_patch_one = GetDoubleDefault(key, -999);
+  sprintf(key, "Solver.OverlandKinematic.SeepageTwo");
+  public_xtra->seepage_patch_two = GetDoubleDefault(key, -999);
+
 
 /* get preconditioner to check for MGSemi to use custom overland flow formulation*/
   precond_switch_na = NA_NewNameArray("NoPC MGSemi SMG PFMG PFMGOctree");


### PR DESCRIPTION
This feature adds a mixed boundary condition capability to ParFlow.  If the top boundary is set to OverlandKinematic and a pfsolid file is used, this solid file can have multiple patches with mixed boundary conditions.  One patch is assigned to the overland kinematic, and up to two more patches can be assigned to seepage face cells mixed in with the overland flow.

tagging @smithsg84 @lecondon to review.