### PR TITLE
Update overlandflow_eval_Kin.c

### DIFF
--- a/pfsimulator/parflow_lib/overlandflow_eval_Kin.c
+++ b/pfsimulator/parflow_lib/overlandflow_eval_Kin.c
@@ -122,8 +122,8 @@ void    OverlandFlowEvalKin(
                                   Locals(int io, itop, ip, ipp1, ippsy;
                                          int k1, k0x, k0y, k1x, k1y;
                                          double Sf_x, Sf_y, Sf_mag;
-                                         double Press_x, Press_y; 
-                                         double PP_ipp1, PP_ippsy, PP_ip;),
+                                         double Press_x, Press_y;
+                                         double PP_ipp1, PP_ippsy, PP_ip; ),
                                   CellSetup(DoNothing),
                                   FACE(LeftFace, DoNothing), FACE(RightFace, DoNothing),
                                   FACE(DownFace, DoNothing), FACE(UpFace, DoNothing),
@@ -151,20 +151,20 @@ void    OverlandFlowEvalKin(
         if (Sf_mag < ov_epsilon)
           Sf_mag = ov_epsilon;
         PP_ipp1 = 0.0;
-        PP_ippsy= 0.0;
+        PP_ippsy = 0.0;
         PP_ip = pp[ip];
         if (ipp1 >= 0)
-           PP_ipp1 = pp[ipp1];
+          PP_ipp1 = pp[ipp1];
         if (ippsy >= 0)
-           PP_ippsy = pp[ippsy];
-    
+          PP_ippsy = pp[ippsy];
+
         Press_x = RPMean(-Sf_x, 0.0,
                          pfmax((PP_ip), 0.0),
                          pfmax((PP_ipp1), 0.0));
         Press_y = RPMean(-Sf_y, 0.0,
                          pfmax((PP_ip), 0.0),
                          pfmax((PP_ippsy), 0.0));
-    
+
         qx_v[io] = -(Sf_x / (RPowerR(fabs(Sf_mag), 0.5) * mann_dat[io]))
                    * RPowerR(Press_x, (5.0 / 3.0));
         qy_v[io] = -(Sf_y / (RPowerR(fabs(Sf_mag), 0.5)


### PR DESCRIPTION
Fix to overlandflow_eval_Kin to correct issue with overland surface boundary and Dirichlet side boundary.

The issue is with the “top” pressure value.  The top function is used here
[k1y = pfmax((int)top_dat[itop + sy_v], 0);](https://github.com/parflow/parflow/blob/483aac5603f6ad69f04e1a12faf5f84859ff5ea6/pfsimulator/parflow_lib/overlandflow_eval_Kin.c#L139) 
[to get the upwinded pressure](https://github.com/parflow/parflow/blob/483aac5603f6ad69f04e1a12faf5f84859ff5ea6/pfsimulator/parflow_lib/overlandflow_eval_Kin.c#L156).
The top value is zero and we are counting on the pressures outside the active domain being zero.  I actually don’t think they always are, I think the BC information gets inserted into the inactive cells adjacent to the boundary and this value at k=0 is what’s being used any time the slopes point into the domain.  This fix checks for the upper right and upper upper top values, if they are <0 (meaning outside the active domain) it assigns an upper pressure of zero, otherwise it assigns the pressure from the upper or right cells (north and east cells) as normal.