### PR TITLE
System NETCDF was found in preference to user specified location

### DIFF
--- a/cmake/modules/FindNetCDF.cmake
+++ b/cmake/modules/FindNetCDF.cmake
@@ -60,6 +60,10 @@ else()
     PATHS "${NETCDF_DIR}/include")
   mark_as_advanced(NETCDF_INCLUDE_DIRS)
 
+  if(NOT NETCDF_INCLUDE_DIRS)
+    message(FATAL_ERROR "NetCDF header netcdf.h not found in ${NETCDF_DIR}/include; could not find NetCDF install")
+  endif ()
+
   find_library(NETCDF_LIBRARIES
     NAMES netcdf
     DOC "netcdf library"
@@ -67,6 +71,11 @@ else()
     PATHS "${NETCDF_DIR}/lib"
     HINTS "${NETCDF_INCLUDE_DIRS}/../lib")
   mark_as_advanced(NETCDF_LIBRARIES)
+
+  if(NOT NETCDF_LIBRARIES)
+    message(FATAL_ERROR "NetCDF library not found in ${NETCDF_DIR}/lib; could not find NetCDF install")
+  endif ()
+
 endif ()
 
 #


### PR DESCRIPTION
When user specified a location for NETCDF_DIR the system paths were searched before the user specified location.   

Modified netcdf find so if user specifies location the system locations are not searched.