### PR TITLE
Simplify PDI installation and fix CUDA atomicAdd support in CI

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -529,9 +529,8 @@ jobs:
           # Configure and install PDI
           mkdir build install
           cd build
-          cmake .. -DCMAKE_INSTALL_PREFIX=../install
+          cmake .. -DCMAKE_INSTALL_PREFIX=${PARFLOW_DEP_DIR}
           make -j 2 install
-          mv -v ${curr_pdi}/pdi ${PARFLOW_DEP_DIR}
         fi
 
         export LD_LIBRARY_PATH=${PARFLOW_DEP_DIR}/pdi/install/lib:${LD_LIBRARY_PATH}

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -555,6 +555,7 @@ jobs:
            -DPARFLOW_AMPS_LAYER=${{ matrix.config.amps_layer }}         \
            -DMPIEXEC_POSTFLAGS='--oversubscribe'                        \
            -DPARFLOW_ACCELERATOR_BACKEND=${{ matrix.config.backend }}   \
+           -DCMAKE_CUDA_ARCHITECTURES="60;70;75;80"                     \
            -DPARFLOW_AMPS_SEQUENTIAL_IO=true                            \
            -DPARFLOW_HAVE_CLM=${HAVE_CLM}                               \
            -DHYPRE_ROOT=$PARFLOW_DEP_DIR                                \


### PR DESCRIPTION
This PR introduces two updates:

1. PDI installation simplification: PDI is now installed directly into PARFLOW_DEP_DIR, aligning with other dependencies and reducing complexity in setup.
2.  Fix for CUDA atomicAdd(double) build error: Added CMAKE_CUDA_ARCHITECTURES=60;70;75;80 to linux.yml to ensure support for double-precision atomicAdd, which requires compute capability ≥ 6.0.

These changes were tested on my fork and passed all CI jobs, including the CUDA build.