### PR TITLE
Refactor allocation of Overland variables

### DIFF
--- a/pfsimulator/parflow_lib/bc_pressure_package.c
+++ b/pfsimulator/parflow_lib/bc_pressure_package.c
@@ -53,6 +53,8 @@ typedef struct {
   int    *patch_indexes;  /* num_patches patch indexes */
   int    *cycle_numbers;  /* num_patches cycle numbers */
   void  **data;           /* num_patches pointers to Type structures */
+
+  int using_overland_flow;
 } PublicXtra;
 
 typedef struct {
@@ -557,6 +559,7 @@ PFModule  *BCPressurePackageNewPublicXtra(
     (public_xtra->patch_indexes) = ctalloc(int, num_patches);
     (public_xtra->cycle_numbers) = ctalloc(int, num_patches);
     (public_xtra->data) = ctalloc(void *, num_patches);
+    (public_xtra->using_overland_flow) = 0;
 
     /* Determine the domain geom index from domain name */
     switch_name = GetString("Domain.GeomName");
@@ -604,7 +607,7 @@ PFModule  *BCPressurePackageNewPublicXtra(
 #if 0 /* Do not undef this block, it is example code not for actual use */
       /* Example flow for setting up TypeStruct for boundary conditions */
       /*
-       * switch yNewPatchType:
+       * switch NewPatchType:
        * {
        * // Allocate the struct, second parameter is whatever variable name you wish to use in this scope
        * NewTypeStruct(MyNewPatchType, data);
@@ -1009,6 +1012,18 @@ PFModule  *BCPressurePackageNewPublicXtra(
           break;
         } /* End OverlandDiffusive */
       } /* End switch types */
+
+      switch ((public_xtra)->input_types[(i)]) 
+      {
+        case OverlandFlow:
+        case OverlandFlowPFB:
+        case OverlandKinematic:
+        case OverlandDiffusive:
+        {
+          (public_xtra->using_overland_flow) = 1;
+          break;
+        }
+      }
     } /* End for patches */
   } /* if patches */
 
@@ -1019,6 +1034,13 @@ PFModule  *BCPressurePackageNewPublicXtra(
   return this_module;
 }
 
+// This function is a hack to take information from the PublicXtra structure
+int BCPressurePackageUsingOverlandFlow(Problem *problem)
+{
+  PFModule *bc_pressure = ProblemBCPressurePackage(problem);
+  PublicXtra *public_xtra = (PublicXtra*)PFModulePublicXtra(bc_pressure);
+  return (public_xtra->using_overland_flow);
+}
 
 /*-------------------------------------------------------------------------
  * BCPressurePackageFreePublicXtra

--- a/pfsimulator/parflow_lib/bc_pressure_package.c
+++ b/pfsimulator/parflow_lib/bc_pressure_package.c
@@ -1013,7 +1013,7 @@ PFModule  *BCPressurePackageNewPublicXtra(
         } /* End OverlandDiffusive */
       } /* End switch types */
 
-      switch ((public_xtra)->input_types[(i)]) 
+      switch ((public_xtra)->input_types[(i)])
       {
         case OverlandFlow:
         case OverlandFlowPFB:
@@ -1039,7 +1039,8 @@ int BCPressurePackageUsingOverlandFlow(Problem *problem)
 {
   PFModule *bc_pressure = ProblemBCPressurePackage(problem);
   PublicXtra *public_xtra = (PublicXtra*)PFModulePublicXtra(bc_pressure);
-  return (public_xtra->using_overland_flow);
+
+  return(public_xtra->using_overland_flow);
 }
 
 /*-------------------------------------------------------------------------

--- a/pfsimulator/parflow_lib/kinsol_nonlin_solver.c
+++ b/pfsimulator/parflow_lib/kinsol_nonlin_solver.c
@@ -124,7 +124,7 @@ int  KINSolInitPC(
   /* The preconditioner module initialized here is the KinsolPC module
    * itself */
 
-  PFModuleReNewInstanceType(KinsolPCInitInstanceXtraInvoke, precond, (NULL, NULL, problem_data, NULL,
+  PFModuleReNewInstanceType(KinsolPCInitInstanceXtraInvoke, precond, (NULL, NULL, NULL, problem_data, NULL,
                                                                       pressure, old_pressure, saturation, density, dt, time));
   return(0);
 }
@@ -300,6 +300,7 @@ int KinsolNonlinSolver(Vector *pressure, Vector *density, Vector *old_density, V
 PFModule  *KinsolNonlinSolverInitInstanceXtra(
                                               Problem *    problem,
                                               Grid *       grid,
+                                              Grid *       grid2d,
                                               ProblemData *problem_data,
                                               double *     temp_data)
 {
@@ -351,20 +352,20 @@ PFModule  *KinsolNonlinSolverInitInstanceXtra(
     if (public_xtra->precond != NULL)
       instance_xtra->precond =
         PFModuleNewInstanceType(KinsolPCInitInstanceXtraInvoke, public_xtra->precond,
-                                (problem, grid, problem_data, temp_data,
+                                (problem, grid, grid2d, problem_data, temp_data,
                                  NULL, NULL, NULL, NULL, 0, 0));
     else
       instance_xtra->precond = NULL;
 
     instance_xtra->nl_function_eval =
       PFModuleNewInstanceType(NlFunctionEvalInitInstanceXtraInvoke, public_xtra->nl_function_eval,
-                              (problem, grid, temp_data));
+                              (problem, grid, grid2d, problem_data, temp_data));
 
     if (public_xtra->richards_jacobian_eval != NULL)
       /* Initialize instance for nonsymmetric matrix */
       instance_xtra->richards_jacobian_eval =
         PFModuleNewInstanceType(RichardsJacobianEvalInitInstanceXtraInvoke, public_xtra->richards_jacobian_eval,
-                                (problem, grid, problem_data, temp_data, 0));
+                                (problem, grid, grid2d, problem_data, temp_data, 0));
     else
       instance_xtra->richards_jacobian_eval = NULL;
   }
@@ -373,15 +374,15 @@ PFModule  *KinsolNonlinSolverInitInstanceXtra(
     if (instance_xtra->precond != NULL)
       PFModuleReNewInstanceType(KinsolPCInitInstanceXtraInvoke,
                                 instance_xtra->precond,
-                                (problem, grid, problem_data, temp_data,
+                                (problem, grid, grid2d, problem_data, temp_data,
                                  NULL, NULL, NULL, NULL, 0, 0));
 
     PFModuleReNewInstanceType(NlFunctionEvalInitInstanceXtraInvoke, instance_xtra->nl_function_eval,
-                              (problem, grid, temp_data));
+                              (problem, grid, grid2d, problem_data, temp_data));
 
     if (instance_xtra->richards_jacobian_eval != NULL)
       PFModuleReNewInstanceType(RichardsJacobianEvalInitInstanceXtraInvoke, instance_xtra->richards_jacobian_eval,
-                                (problem, grid, problem_data, temp_data, 0));
+                                (problem, grid, grid2d, problem_data, temp_data, 0));
   }
 
   /*-----------------------------------------------------------------------

--- a/pfsimulator/parflow_lib/kinsol_nonlin_solver.c
+++ b/pfsimulator/parflow_lib/kinsol_nonlin_solver.c
@@ -359,7 +359,7 @@ PFModule  *KinsolNonlinSolverInitInstanceXtra(
 
     instance_xtra->nl_function_eval =
       PFModuleNewInstanceType(NlFunctionEvalInitInstanceXtraInvoke, public_xtra->nl_function_eval,
-                              (problem, grid, grid2d, problem_data, temp_data));
+                              (problem, grid, grid2d, temp_data));
 
     if (public_xtra->richards_jacobian_eval != NULL)
       /* Initialize instance for nonsymmetric matrix */
@@ -378,7 +378,7 @@ PFModule  *KinsolNonlinSolverInitInstanceXtra(
                                  NULL, NULL, NULL, NULL, 0, 0));
 
     PFModuleReNewInstanceType(NlFunctionEvalInitInstanceXtraInvoke, instance_xtra->nl_function_eval,
-                              (problem, grid, grid2d, problem_data, temp_data));
+                              (problem, grid, grid2d, temp_data));
 
     if (instance_xtra->richards_jacobian_eval != NULL)
       PFModuleReNewInstanceType(RichardsJacobianEvalInitInstanceXtraInvoke, instance_xtra->richards_jacobian_eval,

--- a/pfsimulator/parflow_lib/kinsol_pc.c
+++ b/pfsimulator/parflow_lib/kinsol_pc.c
@@ -85,6 +85,7 @@ void         KinsolPC(Vector *rhs)
 PFModule  *KinsolPCInitInstanceXtra(
                                     Problem *    problem,
                                     Grid *       grid,
+                                    Grid *       grid2d,
                                     ProblemData *problem_data,
                                     double *     temp_data,
                                     Vector *     pressure,
@@ -130,7 +131,7 @@ PFModule  *KinsolPCInitInstanceXtra(
     (instance_xtra->discretization) =
       PFModuleNewInstanceType(
                               RichardsJacobianEvalInitInstanceXtraInvoke,
-                              discretization, (problem, grid, problem_data, temp_data,
+                              discretization, (problem, grid, grid2d, problem_data, temp_data,
                                                pc_matrix_type));
     (instance_xtra->precond) =
       PFModuleNewInstanceType(PrecondInitInstanceXtraInvoke,
@@ -161,7 +162,7 @@ PFModule  *KinsolPCInitInstanceXtra(
   {
     PFModuleReNewInstanceType(RichardsJacobianEvalInitInstanceXtraInvoke,
                               (instance_xtra->discretization),
-                              (problem, grid, problem_data, temp_data, pc_matrix_type));
+                              (problem, grid, grid2d, problem_data, temp_data, pc_matrix_type));
     PFModuleReNewInstanceType(PrecondInitInstanceXtraInvoke,
                               (instance_xtra->precond),
                               (NULL, NULL, problem_data, NULL, NULL, temp_data));

--- a/pfsimulator/parflow_lib/nl_function_eval.c
+++ b/pfsimulator/parflow_lib/nl_function_eval.c
@@ -55,6 +55,15 @@ typedef struct {
   PFModule     *overlandflow_module;  //DOK
   PFModule     *overlandflow_module_diff;  //@RMM
   PFModule     *overlandflow_module_kin;
+
+  // Overland flow variables
+  int           using_overland_flow;
+  Vector       *KW;
+  Vector       *KE;
+  Vector       *KN;
+  Vector       *KS;
+  Vector       *qx;
+  Vector       *qy;
 } InstanceXtra;
 
 /*---------------------------------------------------------------------
@@ -147,8 +156,12 @@ void NlFunctionEval(Vector *     pressure, /* Current pressure values */
   Vector      *source = saturation;
 
   /* Overland flow variables */  //sk
-  Vector      *KW, *KE, *KN, *KS;
-  Vector      *qx, *qy;
+  Vector      *KW = (instance_xtra->KW);
+  Vector      *KE = (instance_xtra->KE);
+  Vector      *KN = (instance_xtra->KN);
+  Vector      *KS = (instance_xtra->KS);
+  Vector      *qx = (instance_xtra->qx);
+  Vector      *qy = (instance_xtra->qy);
   Subvector   *kw_sub, *ke_sub, *kn_sub, *ks_sub, *qx_sub, *qy_sub;
   Subvector   *x_sl_sub;
   // Subvector *y_sl_sub;
@@ -225,6 +238,16 @@ void NlFunctionEval(Vector *     pressure, /* Current pressure values */
   /* Initialize function values to zero. */
   PFVConstInit(0.0, fval);
 
+  if ((instance_xtra->using_overland_flow) == 1)
+  {
+    InitVectorAll(KW, 0.0);
+    InitVectorAll(KE, 0.0);
+    InitVectorAll(KN, 0.0);
+    InitVectorAll(KS, 0.0);
+    InitVectorAll(qx, 0.0);
+    InitVectorAll(qy, 0.0);
+  }
+
   /* diffusive test here, this is NOT PF style and should be
    * re-done putting keys in BC Pressure Package and adding to the
    * datastructure for overlandflowBC */
@@ -236,13 +259,6 @@ void NlFunctionEval(Vector *     pressure, /* Current pressure values */
   /* Pass pressure values to neighbors.  */
   handle = InitVectorUpdate(pressure, VectorUpdateAll);
   FinalizeVectorUpdate(handle);
-
-  KW = NewVectorType(grid2d, 1, 1, vector_cell_centered_2D);
-  KE = NewVectorType(grid2d, 1, 1, vector_cell_centered_2D);
-  KN = NewVectorType(grid2d, 1, 1, vector_cell_centered_2D);
-  KS = NewVectorType(grid2d, 1, 1, vector_cell_centered_2D);
-  qx = NewVectorType(grid2d, 1, 1, vector_cell_centered_2D);
-  qy = NewVectorType(grid2d, 1, 1, vector_cell_centered_2D);
 
   /* Calculate pressure dependent properties: density and saturation */
 
@@ -802,15 +818,28 @@ void NlFunctionEval(Vector *     pressure, /* Current pressure values */
     y_ssl_sub = VectorSubvector(y_ssl, is);
 
     // sk Overland flow
-    kw_sub = VectorSubvector(KW, is);
-    ke_sub = VectorSubvector(KE, is);
-    kn_sub = VectorSubvector(KN, is);
-    ks_sub = VectorSubvector(KS, is);
-    qx_sub = VectorSubvector(qx, is);
-    qy_sub = VectorSubvector(qy, is);
+    if ((instance_xtra->using_overland_flow) == 1)
+    {
+      kw_sub = VectorSubvector(KW, is);
+      ke_sub = VectorSubvector(KE, is);
+      kn_sub = VectorSubvector(KN, is);
+      ks_sub = VectorSubvector(KS, is);
+      qx_sub = VectorSubvector(qx, is);
+      qy_sub = VectorSubvector(qy, is);
+
+      kw_ = SubvectorData(kw_sub);
+      ke_ = SubvectorData(ke_sub);
+      kn_ = SubvectorData(kn_sub);
+      ks_ = SubvectorData(ks_sub);
+      qx_ = SubvectorData(qx_sub);
+      qy_ = SubvectorData(qy_sub);
+    }
     x_sl_sub = VectorSubvector(x_sl, is);
     // y_sl_sub = VectorSubvector(y_sl, is);
     // mann_sub = VectorSubvector(man, is);
+    // x_sl_dat = SubvectorData(x_sl_sub);
+    // y_sl_dat = SubvectorData(y_sl_sub);
+    // mann_dat = SubvectorData(mann_sub);
 
     dx = SubgridDX(subgrid);
     dy = SubgridDY(subgrid);
@@ -852,16 +881,6 @@ void NlFunctionEval(Vector *     pressure, /* Current pressure values */
     vx = SubvectorData(vx_sub);
     vy = SubvectorData(vy_sub);
     vz = SubvectorData(vz_sub);
-
-    kw_ = SubvectorData(kw_sub);
-    ke_ = SubvectorData(ke_sub);
-    kn_ = SubvectorData(kn_sub);
-    ks_ = SubvectorData(ks_sub);
-    qx_ = SubvectorData(qx_sub);
-    qy_ = SubvectorData(qy_sub);
-    // x_sl_dat = SubvectorData(x_sl_sub);
-    // y_sl_dat = SubvectorData(y_sl_sub);
-    // mann_dat = SubvectorData(mann_sub);
 
     pp = SubvectorData(p_sub);
     opp = SubvectorData(op_sub);
@@ -1352,15 +1371,11 @@ void NlFunctionEval(Vector *     pressure, /* Current pressure values */
         {
           /*  @RMM this is modified to be kinematic wave routing, with a new module for diffusive wave
            * routing added */
-          double *dummy1 = NULL;
-          double *dummy2 = NULL;
-          double *dummy3 = NULL;
-          double *dummy4 = NULL;
           PFModuleInvokeType(OverlandFlowEvalDiffInvoke, overlandflow_module_diff,
                              (grid, is, bc_struct, ipatch,
                               problem_data, pressure, old_pressure,
                               ke_, kw_, kn_, ks_,
-                              dummy1, dummy2, dummy3, dummy4,
+                              NULL, NULL, NULL, NULL,
                               qx_, qy_, CALCFCN));
         }
       }),
@@ -1685,14 +1700,10 @@ void NlFunctionEval(Vector *     pressure, /* Current pressure values */
       {
 /*  @RMM this is modified to be kinematic wave routing, with a new module for diffusive wave
  * routing added */
-        double *dummy1 = NULL;
-        double *dummy2 = NULL;
-        double *dummy3 = NULL;
-        double *dummy4 = NULL;
         PFModuleInvokeType(OverlandFlowEvalKinInvoke, overlandflow_module_kin,
                            (grid, is, bc_struct, ipatch, problem_data, pressure,
                             ke_, kw_, kn_, ks_,
-                            dummy1, dummy2, dummy3, dummy4,
+                            NULL, NULL, NULL, NULL,
                             qx_, qy_, CALCFCN));
       }),
                            LoopVars(i, j, k, ival, bc_struct, ipatch, is),
@@ -1911,15 +1922,11 @@ void NlFunctionEval(Vector *     pressure, /* Current pressure values */
       {
         /*  @RMM this is a new module for diffusive wave
          */
-        double *dummy1 = NULL;
-        double *dummy2 = NULL;
-        double *dummy3 = NULL;
-        double *dummy4 = NULL;
         PFModuleInvokeType(OverlandFlowEvalDiffInvoke, overlandflow_module_diff,
                            (grid, is, bc_struct, ipatch,
                             problem_data, pressure, old_pressure,
                             ke_, kw_, kn_, ks_,
-                            dummy1, dummy2, dummy3, dummy4,
+                            NULL, NULL, NULL, NULL,
                             qx_, qy_, CALCFCN));
       }),
                            LoopVars(i, j, k, ival, bc_struct, ipatch, is),
@@ -2193,13 +2200,6 @@ void NlFunctionEval(Vector *     pressure, /* Current pressure values */
 
   EndTiming(public_xtra->time_index);
 
-  FreeVector(KW);
-  FreeVector(KE);
-  FreeVector(KN);
-  FreeVector(KS);
-  FreeVector(qx);
-  FreeVector(qy);
-
   POP_NVTX
 
   return;
@@ -2212,6 +2212,8 @@ void NlFunctionEval(Vector *     pressure, /* Current pressure values */
 
 PFModule    *NlFunctionEvalInitInstanceXtra(Problem *problem,
                                             Grid *   grid,
+                                            Grid *   grid2d,
+                                            ProblemData *problem_data,
                                             double * temp_data)
 
 {
@@ -2254,6 +2256,26 @@ PFModule    *NlFunctionEvalInitInstanceXtra(Problem *problem,
       PFModuleNewInstance(ProblemOverlandFlowEvalDiff(problem), ());   //@RMM
     (instance_xtra->overlandflow_module_kin) =
       PFModuleNewInstance(ProblemOverlandFlowEvalKin(problem), ());
+
+    (instance_xtra->using_overland_flow) = BCPressurePackageUsingOverlandFlow(problem);
+    if ((instance_xtra->using_overland_flow) == 1)
+    {
+      (instance_xtra->KW) = NewVectorType(grid2d, 1, 1, vector_cell_centered_2D);
+      (instance_xtra->KE) = NewVectorType(grid2d, 1, 1, vector_cell_centered_2D);
+      (instance_xtra->KN) = NewVectorType(grid2d, 1, 1, vector_cell_centered_2D);
+      (instance_xtra->KS) = NewVectorType(grid2d, 1, 1, vector_cell_centered_2D);
+      (instance_xtra->qx) = NewVectorType(grid2d, 1, 1, vector_cell_centered_2D);
+      (instance_xtra->qy) = NewVectorType(grid2d, 1, 1, vector_cell_centered_2D);
+    }
+    else
+    {
+      (instance_xtra->KW) = NULL;
+      (instance_xtra->KE) = NULL;
+      (instance_xtra->KN) = NULL;
+      (instance_xtra->KS) = NULL;
+      (instance_xtra->qx) = NULL;
+      (instance_xtra->qy) = NULL;
+    }
   }
   else
   {
@@ -2290,15 +2312,25 @@ void  NlFunctionEvalFreeInstanceXtra()
 
   if (instance_xtra)
   {
-    PFModuleFreeInstance(instance_xtra->density_module);
-    PFModuleFreeInstance(instance_xtra->saturation_module);
-    PFModuleFreeInstance(instance_xtra->rel_perm_module);
-    PFModuleFreeInstance(instance_xtra->phase_source);
-    PFModuleFreeInstance(instance_xtra->bc_pressure);
-    PFModuleFreeInstance(instance_xtra->bc_internal);
-    PFModuleFreeInstance(instance_xtra->overlandflow_module);     //DOK
-    PFModuleFreeInstance(instance_xtra->overlandflow_module_diff);      //@RMM
+    if ((instance_xtra->using_overland_flow) == 1)
+    {
+      FreeVector(instance_xtra->qy);
+      FreeVector(instance_xtra->qx);
+      FreeVector(instance_xtra->KS);
+      FreeVector(instance_xtra->KN);
+      FreeVector(instance_xtra->KE);
+      FreeVector(instance_xtra->KW);
+    }
+
     PFModuleFreeInstance(instance_xtra->overlandflow_module_kin);
+    PFModuleFreeInstance(instance_xtra->overlandflow_module_diff);      //@RMM
+    PFModuleFreeInstance(instance_xtra->overlandflow_module);     //DOK
+    PFModuleFreeInstance(instance_xtra->bc_internal);
+    PFModuleFreeInstance(instance_xtra->bc_pressure);
+    PFModuleFreeInstance(instance_xtra->phase_source);
+    PFModuleFreeInstance(instance_xtra->rel_perm_module);
+    PFModuleFreeInstance(instance_xtra->saturation_module);
+    PFModuleFreeInstance(instance_xtra->density_module);
 
     tfree(instance_xtra);
   }

--- a/pfsimulator/parflow_lib/nl_function_eval.c
+++ b/pfsimulator/parflow_lib/nl_function_eval.c
@@ -57,7 +57,7 @@ typedef struct {
   PFModule     *overlandflow_module_kin;
 
   // Overland flow variables
-  int           using_overland_flow;
+  int using_overland_flow;
   Vector       *KW;
   Vector       *KE;
   Vector       *KN;
@@ -2213,7 +2213,6 @@ void NlFunctionEval(Vector *     pressure, /* Current pressure values */
 PFModule    *NlFunctionEvalInitInstanceXtra(Problem *problem,
                                             Grid *   grid,
                                             Grid *   grid2d,
-                                            ProblemData *problem_data,
                                             double * temp_data)
 
 {

--- a/pfsimulator/parflow_lib/parflow_proto.h
+++ b/pfsimulator/parflow_lib/parflow_proto.h
@@ -446,12 +446,12 @@ void N_VFree(N_Vector x);
 void NewEndpts(double *alpha, double *beta, double *pp, int *size_ptr, int n, double *a_ptr, double *b_ptr, double *cond_ptr, double ereps);
 
 typedef void (*NlFunctionEvalInvoke) (Vector *pressure, Vector *fval, ProblemData *problem_data, Vector *saturation, Vector *old_saturation, Vector *density, Vector *old_density, double dt, double time, Vector *old_pressure, Vector *evap_trans, Vector *ovrl_bc_flx, Vector *x_velocity, Vector *y_velocity, Vector *z_velocity);
-typedef PFModule *(*NlFunctionEvalInitInstanceXtraInvoke) (Problem *problem, Grid *grid, Grid *grid2d, ProblemData *problem_data, double *temp_data);
+typedef PFModule *(*NlFunctionEvalInitInstanceXtraInvoke) (Problem *problem, Grid *grid, Grid *grid2d, double *temp_data);
 
 /* nl_function_eval.c */
 void KINSolFunctionEval(int size, N_Vector pressure, N_Vector fval, void *current_state);
 void NlFunctionEval(Vector *pressure, Vector *fval, ProblemData *problem_data, Vector *saturation, Vector *old_saturation, Vector *density, Vector *old_density, double dt, double time, Vector *old_pressure, Vector *evap_trans, Vector *ovrl_bc_flx, Vector *x_velocity, Vector *y_velocity, Vector *z_velocity);
-PFModule *NlFunctionEvalInitInstanceXtra(Problem *problem, Grid *grid, Grid *grid2d, ProblemData *problem_data, double *temp_data);
+PFModule *NlFunctionEvalInitInstanceXtra(Problem *problem, Grid *grid, Grid *grid2d, double *temp_data);
 void NlFunctionEvalFreeInstanceXtra(void);
 PFModule *NlFunctionEvalNewPublicXtra(char *name);
 

--- a/pfsimulator/parflow_lib/parflow_proto.h
+++ b/pfsimulator/parflow_lib/parflow_proto.h
@@ -38,6 +38,7 @@ void BCPressurePackageFreeInstanceXtra(void);
 PFModule *BCPressurePackageNewPublicXtra(int num_phases);
 void BCPressurePackageFreePublicXtra(void);
 int BCPressurePackageSizeOfTempData(void);
+int BCPressurePackageUsingOverlandFlow(Problem *problem);
 
 /* calc_elevations.c */
 double **CalcElevations(GeomSolid *geom_solid, int ref_patch, SubgridArray *subgrids, ProblemData  *problem_data);
@@ -294,26 +295,26 @@ void InputRFFreePublicXtra(void);
 int InputRFSizeOfTempData(void);
 
 typedef int (*NonlinSolverInvoke) (Vector *pressure, Vector *density, Vector *old_density, Vector *saturation, Vector *old_saturation, double t, double dt, ProblemData *problem_data, Vector *old_pressure, Vector *evap_trans, Vector *ovrl_bc_flx, Vector *x_velocity, Vector *y_velocity, Vector *z_velocity);
-typedef PFModule *(*NonlinSolverInitInstanceXtraInvoke) (Problem *problem, Grid *grid, ProblemData *problem_data, double *temp_data);
+typedef PFModule *(*NonlinSolverInitInstanceXtraInvoke) (Problem *problem, Grid *grid, Grid *grid2d, ProblemData *problem_data, double *temp_data);
 
 /* kinsol_nonlin_solver.c */
 int KINSolInitPC(int neq, N_Vector pressure, N_Vector uscale, N_Vector fval, N_Vector fscale, N_Vector vtemp1, N_Vector vtemp2, void *nl_function, double uround, long int *nfePtr, void *current_state);
 int KINSolCallPC(int neq, N_Vector pressure, N_Vector uscale, N_Vector fval, N_Vector fscale, N_Vector vtem, N_Vector ftem, void *nl_function, double uround, long int *nfePtr, void *current_state);
 void PrintFinalStats(FILE *out_file, long int *integer_outputs_now, long int *integer_outputs_total);
 int KinsolNonlinSolver(Vector *pressure, Vector *density, Vector *old_density, Vector *saturation, Vector *old_saturation, double t, double dt, ProblemData *problem_data, Vector *old_pressure, Vector *evap_trans, Vector *ovrl_bc_flx, Vector *x_velocity, Vector *y_velocity, Vector *z_velocity);
-PFModule *KinsolNonlinSolverInitInstanceXtra(Problem *problem, Grid *grid, ProblemData *problem_data, double *temp_data);
+PFModule *KinsolNonlinSolverInitInstanceXtra(Problem *problem, Grid *grid, Grid *grid2d, ProblemData *problem_data, double *temp_data);
 void KinsolNonlinSolverFreeInstanceXtra(void);
 PFModule *KinsolNonlinSolverNewPublicXtra(void);
 void KinsolNonlinSolverFreePublicXtra(void);
 int KinsolNonlinSolverSizeOfTempData(void);
 
 typedef void (*KinsolPCInvoke) (Vector *rhs);
-typedef PFModule * (*KinsolPCInitInstanceXtraInvoke) (Problem *problem, Grid *grid, ProblemData *problem_data, double *temp_data, Vector *pressure, Vector *old_pressure, Vector *saturation, Vector *density, double dt, double time);
+typedef PFModule * (*KinsolPCInitInstanceXtraInvoke) (Problem *problem, Grid *grid, Grid *grid2d, ProblemData *problem_data, double *temp_data, Vector *pressure, Vector *old_pressure, Vector *saturation, Vector *density, double dt, double time);
 typedef PFModule *(*KinsolPCNewPublicXtraInvoke) (char *name, char *pc_name);
 
 /* kinsol_pc.c */
 void KinsolPC(Vector *rhs);
-PFModule *KinsolPCInitInstanceXtra(Problem *problem, Grid *grid, ProblemData *problem_data, double *temp_data, Vector *pressure, Vector *old_pressure, Vector *saturation, Vector *density, double dt, double time);
+PFModule *KinsolPCInitInstanceXtra(Problem *problem, Grid *grid, Grid *grid2d, ProblemData *problem_data, double *temp_data, Vector *pressure, Vector *old_pressure, Vector *saturation, Vector *density, double dt, double time);
 void KinsolPCFreeInstanceXtra(void);
 PFModule *KinsolPCNewPublicXtra(char *name, char *pc_name);
 void KinsolPCFreePublicXtra(void);
@@ -445,12 +446,12 @@ void N_VFree(N_Vector x);
 void NewEndpts(double *alpha, double *beta, double *pp, int *size_ptr, int n, double *a_ptr, double *b_ptr, double *cond_ptr, double ereps);
 
 typedef void (*NlFunctionEvalInvoke) (Vector *pressure, Vector *fval, ProblemData *problem_data, Vector *saturation, Vector *old_saturation, Vector *density, Vector *old_density, double dt, double time, Vector *old_pressure, Vector *evap_trans, Vector *ovrl_bc_flx, Vector *x_velocity, Vector *y_velocity, Vector *z_velocity);
-typedef PFModule *(*NlFunctionEvalInitInstanceXtraInvoke) (Problem *problem, Grid *grid, double *temp_data);
+typedef PFModule *(*NlFunctionEvalInitInstanceXtraInvoke) (Problem *problem, Grid *grid, Grid *grid2d, ProblemData *problem_data, double *temp_data);
 
 /* nl_function_eval.c */
 void KINSolFunctionEval(int size, N_Vector pressure, N_Vector fval, void *current_state);
 void NlFunctionEval(Vector *pressure, Vector *fval, ProblemData *problem_data, Vector *saturation, Vector *old_saturation, Vector *density, Vector *old_density, double dt, double time, Vector *old_pressure, Vector *evap_trans, Vector *ovrl_bc_flx, Vector *x_velocity, Vector *y_velocity, Vector *z_velocity);
-PFModule *NlFunctionEvalInitInstanceXtra(Problem *problem, Grid *grid, double *temp_data);
+PFModule *NlFunctionEvalInitInstanceXtra(Problem *problem, Grid *grid, Grid *grid2d, ProblemData *problem_data, double *temp_data);
 void NlFunctionEvalFreeInstanceXtra(void);
 PFModule *NlFunctionEvalNewPublicXtra(char *name);
 
@@ -1077,12 +1078,12 @@ void AppendSubregionArray(SubregionArray *sr_array_0, SubregionArray *sr_array_1
 
 
 typedef void (*RichardsJacobianEvalInvoke) (Vector *pressure, Vector *old_pressure, Matrix **ptr_to_J, Matrix **ptr_to_JC, Vector *saturation, Vector *density, ProblemData *problem_data, double dt, double time, int symm_part);
-typedef PFModule *(*RichardsJacobianEvalInitInstanceXtraInvoke) (Problem *problem, Grid *grid, ProblemData *problem_data, double *temp_data, int symmetric_jac);
+typedef PFModule *(*RichardsJacobianEvalInitInstanceXtraInvoke) (Problem *problem, Grid *grid, Grid *grid2d, ProblemData *problem_data, double *temp_data, int symmetric_jac);
 typedef PFModule *(*RichardsJacobianEvalNewPublicXtraInvoke) (char *name);
 /* richards_jacobian_eval.c */
 int KINSolMatVec(void *current_state, N_Vector x, N_Vector y, int *recompute, N_Vector pressure);
 void RichardsJacobianEval(Vector *pressure, Vector *old_pressure, Matrix **ptr_to_J, Matrix **ptr_to_JC, Vector *saturation, Vector *density, ProblemData *problem_data, double dt, double time, int symm_part);
-PFModule *RichardsJacobianEvalInitInstanceXtra(Problem *problem, Grid *grid, ProblemData *problem_data, double *temp_data, int symmetric_jac);
+PFModule *RichardsJacobianEvalInitInstanceXtra(Problem *problem, Grid *grid, Grid *grid2d, ProblemData *problem_data, double *temp_data, int symmetric_jac);
 void RichardsJacobianEvalFreeInstanceXtra(void);
 PFModule *RichardsJacobianEvalNewPublicXtra(char *name);
 void RichardsJacobianEvalFreePublicXtra(void);

--- a/pfsimulator/parflow_lib/richards_jacobian_eval.c
+++ b/pfsimulator/parflow_lib/richards_jacobian_eval.c
@@ -106,7 +106,7 @@ typedef struct {
   Vector       *saturation_der;
 
   // Overland flow variables
-  int           using_overland_flow;
+  int using_overland_flow;
   Vector       *KW;
   Vector       *KE;
   Vector       *KN;
@@ -331,8 +331,8 @@ void    RichardsJacobianEval(
   vector_update_handle = InitVectorUpdate(pressure, VectorUpdateAll);
   FinalizeVectorUpdate(vector_update_handle);
 
-  InitVector(density_der, 0.0);
-  InitVector(saturation_der, 0.0);
+  InitVectorAll(density_der, 0.0);
+  InitVectorAll(saturation_der, 0.0);
 
   // /* Define grid for surface contribution */
   if ((instance_xtra->using_overland_flow) == 1)
@@ -2311,7 +2311,6 @@ PFModule    *RichardsJacobianEvalInitInstanceXtra(
 void  RichardsJacobianEvalFreeInstanceXtra()
 {
   PFModule      *this_module = ThisPFModule;
-  PublicXtra    *public_xtra = (PublicXtra*)PFModulePublicXtra(this_module);
   InstanceXtra  *instance_xtra = (InstanceXtra*)PFModuleInstanceXtra(this_module);
 
   if (instance_xtra)

--- a/pfsimulator/parflow_lib/richards_jacobian_eval.c
+++ b/pfsimulator/parflow_lib/richards_jacobian_eval.c
@@ -101,6 +101,20 @@ typedef struct {
 
   Grid         *grid;
   double       *temp_data;
+
+  Vector       *density_der;
+  Vector       *saturation_der;
+
+  // Overland flow variables
+  int           using_overland_flow;
+  Vector       *KW;
+  Vector       *KE;
+  Vector       *KN;
+  Vector       *KS;
+  Vector       *KWns;
+  Vector       *KEns;
+  Vector       *KNns;
+  Vector       *KSns;
 } InstanceXtra;
 
 /*--------------------------------------------------------------------------
@@ -221,12 +235,12 @@ void    RichardsJacobianEval(
   Matrix      *J = (instance_xtra->J);
   Matrix      *JC = (instance_xtra->JC);
 
-  Vector      *density_der = NULL;
-  Vector      *saturation_der = NULL;
+  Vector      *density_der = (instance_xtra->density_der);
+  Vector      *saturation_der = (instance_xtra->saturation_der);
 
   /* Reuse vectors to save memory */
-  Vector      *rel_perm = NULL;
-  Vector      *rel_perm_der = NULL;
+  Vector      *rel_perm = saturation;
+  Vector      *rel_perm_der = saturation_der;
 
   Vector      *porosity = ProblemDataPorosity(problem_data);
   Vector      *permeability_x = ProblemDataPermeabilityX(problem_data);
@@ -237,7 +251,14 @@ void    RichardsJacobianEval(
   Vector      *slope_x = ProblemDataTSlopeX(problem_data);                //DOK
 
   /* Overland flow variables */  //DOK
-  Vector      *KW, *KE, *KN, *KS, *KWns, *KEns, *KNns, *KSns;
+  Vector      *KW = (instance_xtra->KW);
+  Vector      *KE = (instance_xtra->KE);
+  Vector      *KN = (instance_xtra->KN);
+  Vector      *KS = (instance_xtra->KS);
+  Vector      *KWns = (instance_xtra->KWns);
+  Vector      *KEns = (instance_xtra->KEns);
+  Vector      *KNns = (instance_xtra->KNns);
+  Vector      *KSns = (instance_xtra->KSns);
   Subvector   *kw_sub, *ke_sub, *kn_sub, *ks_sub, *kwns_sub, *kens_sub, *knns_sub, *ksns_sub, *top_sub, *sx_sub;
   double      *kw_der, *ke_der, *kn_der, *ks_der, *kwns_der, *kens_der, *knns_der, *ksns_der;
 
@@ -306,74 +327,25 @@ void    RichardsJacobianEval(
   CommHandle  *handle;
   VectorUpdateCommHandle  *vector_update_handle;
 
-  // Determine if an overland flow boundary condition is being used.
-  // If so will use the analytic Jacobian.
-  if (public_xtra->type == not_set)
-  {
-    // Default to simple
-    public_xtra->type = simple;
-
-    BCPressureData   *bc_pressure_data
-      = ProblemDataBCPressureData(problem_data);
-    int num_patches = BCPressureDataNumPatches(bc_pressure_data);
-
-    if (num_patches > 0)
-    {
-      int i;
-      for (i = 0; i < num_patches; i++)
-      {
-        int type = BCPressureDataType(bc_pressure_data, i);
-        switch (type)
-        {
-          case OverlandFlow:
-          case OverlandKinematic:
-          case OverlandDiffusive:
-          {
-            public_xtra->type = overland_flow;
-            /*If we have MGSemi set as the preconditioner key
-             * we still set the type to overland_flow
-             * but later use the simple/symmetric preconditioner (RMM) */
-          }
-          break;
-        }
-      }
-    }
-  }
-
-  /*-----------------------------------------------------------------------
-   * Allocate temp vectors
-   *-----------------------------------------------------------------------*/
-  density_der = NewVectorType(grid, 1, 1, vector_cell_centered);
-  saturation_der = NewVectorType(grid, 1, 1, vector_cell_centered);
-
-  /*-----------------------------------------------------------------------
-   * reuse the temp vectors for both saturation and rel_perm calculations.
-   *-----------------------------------------------------------------------*/
-  rel_perm = saturation;
-  rel_perm_der = saturation_der;
-
   /* Pass pressure values to neighbors.  */
   vector_update_handle = InitVectorUpdate(pressure, VectorUpdateAll);
   FinalizeVectorUpdate(vector_update_handle);
 
-/* Define grid for surface contribution */
-  KW = NewVectorType(grid2d, 1, 1, vector_cell_centered);
-  KE = NewVectorType(grid2d, 1, 1, vector_cell_centered);
-  KN = NewVectorType(grid2d, 1, 1, vector_cell_centered);
-  KS = NewVectorType(grid2d, 1, 1, vector_cell_centered);
-  KWns = NewVectorType(grid2d, 1, 1, vector_cell_centered);
-  KEns = NewVectorType(grid2d, 1, 1, vector_cell_centered);
-  KNns = NewVectorType(grid2d, 1, 1, vector_cell_centered);
-  KSns = NewVectorType(grid2d, 1, 1, vector_cell_centered);
+  InitVector(density_der, 0.0);
+  InitVector(saturation_der, 0.0);
 
-  InitVector(KW, 0.0);
-  InitVector(KE, 0.0);
-  InitVector(KN, 0.0);
-  InitVector(KS, 0.0);
-  InitVector(KWns, 0.0);
-  InitVector(KEns, 0.0);
-  InitVector(KNns, 0.0);
-  InitVector(KSns, 0.0);
+  // /* Define grid for surface contribution */
+  if ((instance_xtra->using_overland_flow) == 1)
+  {
+    InitVectorAll(KW, 0.0);
+    InitVectorAll(KE, 0.0);
+    InitVectorAll(KN, 0.0);
+    InitVectorAll(KS, 0.0);
+    InitVectorAll(KWns, 0.0);
+    InitVectorAll(KEns, 0.0);
+    InitVectorAll(KNns, 0.0);
+    InitVectorAll(KSns, 0.0);
+  }
 
   // SGS set this to 1 since the off/on behavior does not work in
   // parallel.
@@ -981,14 +953,27 @@ void    RichardsJacobianEval(
     J_sub = MatrixSubmatrix(J, is);
 
     /* overland flow - DOK */
-    kw_sub = VectorSubvector(KW, is);
-    ke_sub = VectorSubvector(KE, is);
-    kn_sub = VectorSubvector(KN, is);
-    ks_sub = VectorSubvector(KS, is);
-    kwns_sub = VectorSubvector(KWns, is);
-    kens_sub = VectorSubvector(KEns, is);
-    knns_sub = VectorSubvector(KNns, is);
-    ksns_sub = VectorSubvector(KSns, is);
+    if ((instance_xtra->using_overland_flow) == 1)
+    {
+      kw_sub = VectorSubvector(KW, is);
+      ke_sub = VectorSubvector(KE, is);
+      kn_sub = VectorSubvector(KN, is);
+      ks_sub = VectorSubvector(KS, is);
+      kwns_sub = VectorSubvector(KWns, is);
+      kens_sub = VectorSubvector(KEns, is);
+      knns_sub = VectorSubvector(KNns, is);
+      ksns_sub = VectorSubvector(KSns, is);
+
+      /* overland flow contribution */
+      kw_der = SubvectorData(kw_sub);
+      ke_der = SubvectorData(ke_sub);
+      kn_der = SubvectorData(kn_sub);
+      ks_der = SubvectorData(ks_sub);
+      kwns_der = SubvectorData(kwns_sub);
+      kens_der = SubvectorData(kens_sub);
+      knns_der = SubvectorData(knns_sub);
+      ksns_der = SubvectorData(ksns_sub);
+    }
 
     dx = SubgridDX(subgrid);
     dy = SubgridDY(subgrid);
@@ -1021,16 +1006,6 @@ void    RichardsJacobianEval(
     np = SubmatrixStencilData(J_sub, 4);
     lp = SubmatrixStencilData(J_sub, 5);
     up = SubmatrixStencilData(J_sub, 6);
-
-    /* overland flow contribution */
-    kw_der = SubvectorData(kw_sub);
-    ke_der = SubvectorData(ke_sub);
-    kn_der = SubvectorData(kn_sub);
-    ks_der = SubvectorData(ks_sub);
-    kwns_der = SubvectorData(kwns_sub);
-    kens_der = SubvectorData(kens_sub);
-    knns_der = SubvectorData(knns_sub);
-    ksns_der = SubvectorData(ksns_sub);
 
     pp = SubvectorData(p_sub);
     sp = SubvectorData(s_sub);
@@ -1440,30 +1415,33 @@ void    RichardsJacobianEval(
       FinalizeMatrixUpdate(handle);
     }
 
-    /* Pass KW values to neighbors.  */
-    vector_update_handle = InitVectorUpdate(KW, VectorUpdateAll);
-    FinalizeVectorUpdate(vector_update_handle);
-    /* Pass KE values to neighbors.  */
-    vector_update_handle = InitVectorUpdate(KE, VectorUpdateAll);
-    FinalizeVectorUpdate(vector_update_handle);
-    /* Pass KS values to neighbors.  */
-    vector_update_handle = InitVectorUpdate(KS, VectorUpdateAll);
-    FinalizeVectorUpdate(vector_update_handle);
-    /* Pass KN values to neighbors.  */
-    vector_update_handle = InitVectorUpdate(KN, VectorUpdateAll);
-    FinalizeVectorUpdate(vector_update_handle);
-    /* Pass KWns values to neighbors.  */
-    vector_update_handle = InitVectorUpdate(KWns, VectorUpdateAll);
-    FinalizeVectorUpdate(vector_update_handle);
-    /* Pass KEns values to neighbors.  */
-    vector_update_handle = InitVectorUpdate(KEns, VectorUpdateAll);
-    FinalizeVectorUpdate(vector_update_handle);
-    /* Pass KSns values to neighbors.  */
-    vector_update_handle = InitVectorUpdate(KSns, VectorUpdateAll);
-    FinalizeVectorUpdate(vector_update_handle);
-    /* Pass KNns values to neighbors.  */
-    vector_update_handle = InitVectorUpdate(KNns, VectorUpdateAll);
-    FinalizeVectorUpdate(vector_update_handle);
+    if ((instance_xtra->using_overland_flow) == 1)
+    {
+      /* Pass KW values to neighbors.  */
+      vector_update_handle = InitVectorUpdate(KW, VectorUpdateAll);
+      FinalizeVectorUpdate(vector_update_handle);
+      /* Pass KE values to neighbors.  */
+      vector_update_handle = InitVectorUpdate(KE, VectorUpdateAll);
+      FinalizeVectorUpdate(vector_update_handle);
+      /* Pass KS values to neighbors.  */
+      vector_update_handle = InitVectorUpdate(KS, VectorUpdateAll);
+      FinalizeVectorUpdate(vector_update_handle);
+      /* Pass KN values to neighbors.  */
+      vector_update_handle = InitVectorUpdate(KN, VectorUpdateAll);
+      FinalizeVectorUpdate(vector_update_handle);
+      /* Pass KWns values to neighbors.  */
+      vector_update_handle = InitVectorUpdate(KWns, VectorUpdateAll);
+      FinalizeVectorUpdate(vector_update_handle);
+      /* Pass KEns values to neighbors.  */
+      vector_update_handle = InitVectorUpdate(KEns, VectorUpdateAll);
+      FinalizeVectorUpdate(vector_update_handle);
+      /* Pass KSns values to neighbors.  */
+      vector_update_handle = InitVectorUpdate(KSns, VectorUpdateAll);
+      FinalizeVectorUpdate(vector_update_handle);
+      /* Pass KNns values to neighbors.  */
+      vector_update_handle = InitVectorUpdate(KNns, VectorUpdateAll);
+      FinalizeVectorUpdate(vector_update_handle);
+    }
   }
 
   /* Build submatrix JC if overland flow case and *not* MGSemi*/
@@ -1871,14 +1849,26 @@ void    RichardsJacobianEval(
 
       J_sub = MatrixSubmatrix(J, is);
 
-      kw_sub = VectorSubvector(KW, is);
-      ke_sub = VectorSubvector(KE, is);
-      kn_sub = VectorSubvector(KN, is);
-      ks_sub = VectorSubvector(KS, is);
-      kwns_sub = VectorSubvector(KWns, is);
-      kens_sub = VectorSubvector(KEns, is);
-      knns_sub = VectorSubvector(KNns, is);
-      ksns_sub = VectorSubvector(KSns, is);
+      if ((instance_xtra->using_overland_flow) == 1)
+      {
+        kw_sub = VectorSubvector(KW, is);
+        ke_sub = VectorSubvector(KE, is);
+        kn_sub = VectorSubvector(KN, is);
+        ks_sub = VectorSubvector(KS, is);
+        kwns_sub = VectorSubvector(KWns, is);
+        kens_sub = VectorSubvector(KEns, is);
+        knns_sub = VectorSubvector(KNns, is);
+        ksns_sub = VectorSubvector(KSns, is);
+
+        kw_der = SubvectorData(kw_sub);
+        ke_der = SubvectorData(ke_sub);
+        kn_der = SubvectorData(kn_sub);
+        ks_der = SubvectorData(ks_sub);
+        kwns_der = SubvectorData(kwns_sub);
+        kens_der = SubvectorData(kens_sub);
+        knns_der = SubvectorData(knns_sub);
+        ksns_der = SubvectorData(ksns_sub);
+      }
 
       top_sub = VectorSubvector(top, is);
       sx_sub = VectorSubvector(slope_x, is);
@@ -1905,15 +1895,6 @@ void    RichardsJacobianEval(
       np = SubmatrixStencilData(J_sub, 4);
       lp = SubmatrixStencilData(J_sub, 5);
       up = SubmatrixStencilData(J_sub, 6);
-
-      kw_der = SubvectorData(kw_sub);
-      ke_der = SubvectorData(ke_sub);
-      kn_der = SubvectorData(kn_sub);
-      ks_der = SubvectorData(ks_sub);
-      kwns_der = SubvectorData(kwns_sub);
-      kens_der = SubvectorData(kens_sub);
-      knns_der = SubvectorData(knns_sub);
-      ksns_der = SubvectorData(ksns_sub);
 
       top_dat = SubvectorData(top_sub);
 
@@ -2168,17 +2149,6 @@ void    RichardsJacobianEval(
 
   FreeBCStruct(bc_struct);
 
-  FreeVector(density_der);
-  FreeVector(saturation_der);
-  FreeVector(KW);
-  FreeVector(KE);
-  FreeVector(KN);
-  FreeVector(KS);
-  FreeVector(KWns);
-  FreeVector(KEns);
-  FreeVector(KNns);
-  FreeVector(KSns);
-
   tfree(ovlnd_flag);
 
   POP_NVTX
@@ -2194,11 +2164,13 @@ void    RichardsJacobianEval(
 PFModule    *RichardsJacobianEvalInitInstanceXtra(
                                                   Problem *    problem,
                                                   Grid *       grid,
+                                                  Grid *       grid2d,
                                                   ProblemData *problem_data,
                                                   double *     temp_data,
                                                   int          symmetric_jac)
 {
   PFModule      *this_module = ThisPFModule;
+  PublicXtra    *public_xtra = (PublicXtra*)PFModulePublicXtra(this_module);
   InstanceXtra  *instance_xtra;
 
   Stencil       *stencil, *stencil_C;
@@ -2270,6 +2242,47 @@ PFModule    *RichardsJacobianEvalInitInstanceXtra(
       PFModuleNewInstance(ProblemOverlandFlowEvalDiff(problem), ());   //RMM-LEC
     (instance_xtra->overlandflow_module_kin)
       = PFModuleNewInstance(ProblemOverlandFlowEvalKin(problem), ());
+
+    // Allocate vectors for the derivatives
+    (instance_xtra->density_der) = NewVectorType(grid, 1, 1, vector_cell_centered);
+    (instance_xtra->saturation_der) = NewVectorType(grid, 1, 1, vector_cell_centered);
+
+    (instance_xtra->using_overland_flow) = BCPressurePackageUsingOverlandFlow(problem);
+    if (public_xtra->type == not_set)
+    {
+      // Default to simple
+      public_xtra->type = simple;
+      if ((instance_xtra->using_overland_flow) == 1)
+      {
+        (public_xtra->type) = overland_flow;
+      }
+      /* If we have MGSemi set as the preconditioner key
+       * we still set the type to overland_flow
+       * but later use the simple/symmetric preconditioner (RMM) */
+    }
+
+    if ((instance_xtra->using_overland_flow) == 1)
+    {
+      (instance_xtra->KW) = NewVectorType(grid2d, 1, 1, vector_cell_centered_2D);
+      (instance_xtra->KE) = NewVectorType(grid2d, 1, 1, vector_cell_centered_2D);
+      (instance_xtra->KN) = NewVectorType(grid2d, 1, 1, vector_cell_centered_2D);
+      (instance_xtra->KS) = NewVectorType(grid2d, 1, 1, vector_cell_centered_2D);
+      (instance_xtra->KWns) = NewVectorType(grid2d, 1, 1, vector_cell_centered_2D);
+      (instance_xtra->KEns) = NewVectorType(grid2d, 1, 1, vector_cell_centered_2D);
+      (instance_xtra->KNns) = NewVectorType(grid2d, 1, 1, vector_cell_centered_2D);
+      (instance_xtra->KSns) = NewVectorType(grid2d, 1, 1, vector_cell_centered_2D);
+    }
+    else
+    {
+      (instance_xtra->KW) = NULL;
+      (instance_xtra->KE) = NULL;
+      (instance_xtra->KN) = NULL;
+      (instance_xtra->KS) = NULL;
+      (instance_xtra->KWns) = NULL;
+      (instance_xtra->KEns) = NULL;
+      (instance_xtra->KNns) = NULL;
+      (instance_xtra->KSns) = NULL;
+    }
   }
   else
   {
@@ -2298,18 +2311,34 @@ PFModule    *RichardsJacobianEvalInitInstanceXtra(
 void  RichardsJacobianEvalFreeInstanceXtra()
 {
   PFModule      *this_module = ThisPFModule;
+  PublicXtra    *public_xtra = (PublicXtra*)PFModulePublicXtra(this_module);
   InstanceXtra  *instance_xtra = (InstanceXtra*)PFModuleInstanceXtra(this_module);
 
   if (instance_xtra)
   {
-    PFModuleFreeInstance(instance_xtra->density_module);
-    PFModuleFreeInstance(instance_xtra->bc_pressure);
-    PFModuleFreeInstance(instance_xtra->saturation_module);
-    PFModuleFreeInstance(instance_xtra->rel_perm_module);
-    PFModuleFreeInstance(instance_xtra->bc_internal);
-    PFModuleFreeInstance(instance_xtra->overlandflow_module);     //DOK
-    PFModuleFreeInstance(instance_xtra->overlandflow_module_diff);       //RMM-LEC
+    if ((instance_xtra->using_overland_flow) == 1)
+    {
+      FreeVector(instance_xtra->KSns);
+      FreeVector(instance_xtra->KNns);
+      FreeVector(instance_xtra->KEns);
+      FreeVector(instance_xtra->KWns);
+      FreeVector(instance_xtra->KS);
+      FreeVector(instance_xtra->KN);
+      FreeVector(instance_xtra->KE);
+      FreeVector(instance_xtra->KW);
+    }
+
+    FreeVector(instance_xtra->saturation_der);
+    FreeVector(instance_xtra->density_der);
+
     PFModuleFreeInstance(instance_xtra->overlandflow_module_kin);
+    PFModuleFreeInstance(instance_xtra->overlandflow_module_diff);       //RMM-LEC
+    PFModuleFreeInstance(instance_xtra->overlandflow_module);     //DOK
+    PFModuleFreeInstance(instance_xtra->bc_internal);
+    PFModuleFreeInstance(instance_xtra->rel_perm_module);
+    PFModuleFreeInstance(instance_xtra->saturation_module);
+    PFModuleFreeInstance(instance_xtra->bc_pressure);
+    PFModuleFreeInstance(instance_xtra->density_module);
 
     FreeMatrix(instance_xtra->J);
 

--- a/pfsimulator/parflow_lib/solver_richards.c
+++ b/pfsimulator/parflow_lib/solver_richards.c
@@ -4778,7 +4778,7 @@ SolverRichardsInitInstanceXtra()
     (instance_xtra->nonlin_solver) =
       PFModuleNewInstanceType(NonlinSolverInitInstanceXtraInvoke,
                               public_xtra->nonlin_solver,
-                              (problem, grid, instance_xtra->problem_data,
+                              (problem, grid, grid2d, instance_xtra->problem_data,
                                NULL));
   }
   else
@@ -4874,7 +4874,7 @@ SolverRichardsInitInstanceXtra()
   /* renew nonlinear solver module */
   PFModuleReNewInstanceType(NonlinSolverInitInstanceXtraInvoke,
                             (instance_xtra->nonlin_solver),
-                            (NULL, NULL, instance_xtra->problem_data,
+                            (NULL, NULL, NULL, instance_xtra->problem_data,
                              temp_data));
 
   /* renew set_problem_data module */


### PR DESCRIPTION
This PR addresses an issue brought up during the core ParFlow developer meeting of June 9th, 2025.

In summary, there were identified a combined total of 16 variables in the main `NlFunctionEval()` and `RichardsJacobianEval()` modules that were allocated and deallocated at every invoke call of the modules, which can happen multiple times in each nonlinear iteration.
Additionally, most of these variables are only used when a boundary condition (BC) of the type OverlandFlow is active.

Therefore, this PR introduces a few updates:
1. Moves variable allocation outside of the iteration loop;
2. Only allocates variables when OverlandFlow-type BCs are active;
3. Achieves performance gains in solver time around 12% for problems without OverlandFlow;
4. Achieves performance gains in solver time around 8% for problems with OverlandFlow;
5. Achieves small memory savings for problems without OverlandFlow.