### PR TITLE
Limit where self hosted runner is used

### DIFF
--- a/.github/workflows/self_hosted.yml
+++ b/.github/workflows/self_hosted.yml
@@ -4,6 +4,8 @@ on: [push, pull_request]
 
 jobs:
   test-gpu:
+    # only run GPU test if in parflow project
+    if github.repository == 'parflow/parflow'
     name: ${{ matrix.config.name }}
     runs-on: self-hosted
     strategy:

--- a/.github/workflows/self_hosted.yml
+++ b/.github/workflows/self_hosted.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 jobs:
   test-gpu:
     # only run GPU test if in parflow project
-    if github.repository == 'parflow/parflow'
+    if: github.repository == 'parflow/parflow'
     name: ${{ matrix.config.name }}
     runs-on: self-hosted
     strategy:


### PR DESCRIPTION
Self host runner only works from within the ParFlow project, skip the test when run from forks to save time waiting for test to time-out.