### PR TITLE
Refactor Zero-Initialization MemSet for Improved Kokkos Performance

### DIFF
--- a/pfsimulator/amps/mpi1/amps_gpupacking.cpp
+++ b/pfsimulator/amps/mpi1/amps_gpupacking.cpp
@@ -293,23 +293,17 @@ void kokkosMemCpyUVMToUVM(char *dest, char *src, size_t size){
  * @param ptr Pointer for the data to be set to zero
  * @param size Bytes to be zeroed
  */
-void kokkosMemSetAmps(char *ptr, size_t size){
-  /* Loop style initialization */
-  if(size % sizeof(int))
-  {
-    /* Writing 1 byte / thread is slow */
-    Kokkos::parallel_for(size, KOKKOS_LAMBDA(int i){ptr[i] = 0;});
-  }
-  else
-  {
-    /* Writing 4 bytes / thread is fast */
-    Kokkos::parallel_for(size / sizeof(int), KOKKOS_LAMBDA(int i){((int*)ptr)[i] = 0;});
-  }
-  Kokkos::fence(); 
+void kokkosMemSetAmps(char* ptr, size_t size) {
+  using ExecSpace = Kokkos::DefaultExecutionSpace;
 
-  /* Deep_copy style initialization for char* should be fast in future Kokkos releases */
-  // Kokkos::View<char*> ptr_view(ptr, size);
-  // Kokkos::deep_copy(ptr_view, 0);
+  // Create an unmanaged view over the raw memory
+  Kokkos::View<char*, Kokkos::MemoryUnmanaged> view(ptr, size);
+
+  // Perform efficient parallel zero-initialization
+  Kokkos::deep_copy(ExecSpace(), view, (char)0);
+
+  // Synchronize only the current execution space (e.g., CUDA, HIP, etc.)
+  ExecSpace().fence();
 }
   
 /**


### PR DESCRIPTION
This PR refactors `KokkosMemSet` operations by replacing manual zero-initialization via `parallel_for `with a more efficient and portable `Kokkos::deep_copy` on unmanaged memory views. This improves overall Kokkos performance, simplifies logic, and aligns with modern Kokkos best practices.

**Summary of Changes:**

- Replaced loop-based based zeroing with `Kokkos::deep_copy` using unmanaged views.
- Scoped synchronization instead of a global `Kokkos::fence()`.
- Removed alignment-based branching logic, simplifying code and improving readability.

**Performance Comparison (vs Native CUDA on NVIDIA A100):**

- Up to ~38% reduction in solve time compared to the previous loop based implementation.
- Performance gap with native CUDA closes up to ~95%.