### PR TITLE
Use file hashes to trigger Github Actions cache builds

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -77,7 +77,7 @@ jobs:
                echo "Installing"
                mkdir -p $HOME/depend/{include,lib}
                cd $HOME/depend
-               echo "cache-${{ matrix.config.os }}-${{ matrix.config.backend }}-${{ secrets.CACHE_VERSION }}" > $HOME/depend/cache-key
+               echo "cache-${{ matrix.config.os }}-${{ matrix.config.backend }}-${{ hashfiles('**/.github/workflows/linux.yml') }}" > $HOME/depend/cache-key
                wget -nv --no-check-certificate https://github.com/Kitware/CMake/releases/download/v3.25.1/cmake-3.25.1-linux-x86_64.tar.gz
                tar -xf cmake-3.25.1-linux-x86_64.tar.gz
                $HOME/depend/cmake-3.25.1-linux-x86_64/bin/cmake --version
@@ -273,10 +273,6 @@ jobs:
       run: |
         sudo apt-get -qq update
         sudo apt -qq install python3 python3-venv
-
-    # Cache dependencies so don't have to rebuild on each test.
-    # Can flush caches by resetting the CACHE_VERSION secret on GitHub
-    # settings for the project (using date-timestamp for secret).
 
     - name: Cache dependencies
       uses: actions/cache@v4

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -25,7 +25,7 @@ jobs:
            cache-parflow-style-hit: ${{steps.cache-parflow-style-dependencies.outputs.cache-hit}}
          with:
            path: "~/depend"
-           key: cache-check-style-${{ secrets.CACHE_VERSION }}
+           key: cache-check-style-${{ hashfiles('**/.github/workflows/linux.yml') }}
 
        - name: Directory Setup
          run: |
@@ -56,7 +56,7 @@ jobs:
            CACHE_HIT: ${{steps.cache-parflow-style-dependencies.outputs.cache-hit}}
          run: |
             if [[ "$CACHE_HIT" != 'true' ]]; then
-              echo "cache-check-style-${{ secrets.CACHE_VERSION }}" > $HOME/depend/cache-key
+              echo "cache-check-style-${{ hashfiles('**/.github/workflows/linux.yml') }}" > $HOME/depend/cache-key
               curl -L -o uncrustify-0.79.0.tar.gz https://github.com/uncrustify/uncrustify/archive/uncrustify-0.79.0.tar.gz
               tar -xf uncrustify-0.79.0.tar.gz
               cd uncrustify-uncrustify-0.79.0
@@ -286,7 +286,7 @@ jobs:
         cache-parflow-hit: ${{steps.cache-parflow-dependencies.outputs.cache-hit}}
       with:
         path: "~/depend"
-        key: cache-${{ matrix.config.os }}-${{ matrix.config.backend }}-${{ matrix.config.memory_manager }}-${{ matrix.config.pdi }}-${{ secrets.CACHE_VERSION }}
+        key: cache-${{ matrix.config.os }}-${{ matrix.config.backend }}-${{ matrix.config.memory_manager }}-${{ matrix.config.pdi }}-${{ hashfiles('**/.github/workflows/linux.yml') }}
 
     - name: Directory Setup
       run: |
@@ -331,7 +331,7 @@ jobs:
        if [[ "$CACHE_HIT" != 'true' ]]; then
           echo "Installing CMake v3.26.5"
           cd $HOME/depend
-          echo "cache-${{ matrix.config.os }}-${{ matrix.config.backend }}-${{ secrets.CACHE_VERSION }}" > $HOME/depend/cache-key
+          echo "cache-${{ matrix.config.os }}-${{ matrix.config.backend }}-${{ hashfiles('**/.github/workflows/linux.yml') }}" > $HOME/depend/cache-key
           wget -nv --no-check-certificate https://github.com/Kitware/CMake/releases/download/v3.26.5/cmake-3.26.5-linux-x86_64.tar.gz
           tar -xf cmake-3.26.5-linux-x86_64.tar.gz
           $HOME/depend/cmake-3.26.5-linux-x86_64/bin/cmake --version

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -45,10 +45,6 @@ jobs:
       run: |
         brew link tcl-tk@8
 
-# Cache dependencies so don't have to rebuild on each test.
-# Can flush caches by resetting the CACHE_VERSION secret on GitHub
-# settings for the project (using date-timestamp for secret).
-
     - name: Cache dependencies
       uses: actions/cache@v4
       id: cache-parflow-dependencies
@@ -57,7 +53,7 @@ jobs:
         cache-parflow-hit: ${{steps.cache-parflow-dependencies.outputs.cache-hit}}
       with:
         path: "~/depend"
-        key: cache-${{ matrix.config.os }}-${{ matrix.config.backend }}-${{ secrets.CACHE_VERSION }}
+        key: cache-${{ matrix.config.os }}-${{ matrix.config.backend }}-${{ hashfiles('**/.github/workflows/macos.yml') }}
 
     - name: Directory Setup
       run: |
@@ -82,7 +78,7 @@ jobs:
        if [[ "$CACHE_HIT" != 'true' ]]; then
           echo "Installing"
           cd ~/depend
-          echo "cache-${{ matrix.config.os }}-${{ matrix.config.backend }}-${{ secrets.CACHE_VERSION }}" > ~/depend/cache-key
+          echo "cache-${{ matrix.config.os }}-${{ matrix.config.backend }}-${{ hashfiles('**/.github/workflows/macos.yml') }}" > ~/depend/cache-key
           wget -nv --no-check-certificate https://github.com/Kitware/CMake/releases/download/v3.25.1/cmake-3.25.1-linux-x86_64.tar.gz
           tar -xf cmake-3.25.1-linux-x86_64.tar.gz
           $HOME/depend/cmake-3.25.1-linux-x86_64/bin/cmake --version


### PR DESCRIPTION
Previous method of using variable to force rebuilds was manual and caused issues.   Forks can not see the cache variable which also can cause problems.   Changed to use hash of the workflow files to trigger cache builds.   This is conservative and will cause some unnecessary builds but workflow changes are relatively infrequent.