### PR TITLE
Fix dependencies in pyproject.toml

### DIFF
--- a/pftools/python/pyproject.toml
+++ b/pftools/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pftools"
-version = "1.3.13"
+version = "1.3.14"
 description = "A Python package creating an interface with the ParFlow hydrologic model."
 readme = "README.md"
 license = {text = "BSD"}

--- a/pftools/python/pyproject.toml
+++ b/pftools/python/pyproject.toml
@@ -21,26 +21,24 @@ classifiers = [
 ]
 requires-python = ">=3.7"
 dependencies = [
-    "pyyaml>=6.0.1",
+    "pyyaml==6.0.1",
+    "xarray",
+    "pandas",
+    "numba",
+    "numpy",
+    "dask"
 ]
 
 [project.optional-dependencies]
 all = [
     "imageio>=2.9.0",
-    "numpy",
-    "xarray",
-    "numba",
-    "dask",
     "h5py",
+    "twine",
+    "black"
 ]
 pfsol = ["imageio>=2.9.0"]
-io = [
-    "numpy",
-    "xarray",
-    "dask",
-]
-fastio = ["numba"]
 pdi = ["h5py"]
+dev = ["twine", "black"]
 
 [project.urls]
 Homepage = "https://github.com/parflow/parflow/tree/master/pftools/python"


### PR DESCRIPTION
With the new pftools build, the dependencies like numpy and pandas weren't pulled automatically. This PR fixes this. We also need to publish a new pftools version on PyPI so that this is available to users.