### PR TITLE
pf_omploops.h: Fix an error from overloaded __throw_ios_failure C++ functions

### DIFF
--- a/pfsimulator/parflow_lib/pf_omploops.h
+++ b/pfsimulator/parflow_lib/pf_omploops.h
@@ -40,7 +40,9 @@
 
 #else
 
+extern "C++" {
 #include <omp.h>
+}
 #include <stdarg.h>
 
 /**


### PR DESCRIPTION
This PR fixes the following GCC 15+ error from the overloaded `__throw_ios_failure` C++ functions.
```
In file included from /usr/lib64/gcc/x86_64-slackware-linux/15.1.0/include/omp.h:438,
                 from /home/hcho/usr/local/src/parflow/pfsimulator/parflow_lib/pf_omploops.h:43,
                 from /home/hcho/usr/local/src/parflow/pfsimulator/parflow_lib/backend_mapping.h:71,
                 from /home/hcho/usr/local/src/parflow/pfsimulator/parflow_lib/parflow.h:81,
                 from /home/hcho/usr/local/src/parflow/pfsimulator/parflow_lib/overlandflow_eval_Kin.c:38,
                 from /home/hcho/usr/local/src/parflow/pfsimulator/parflow_lib/overlandflow_eval_Kin.cpp:22:
/usr/include/c++/15.1.0/bits/functexcept.h:102:3: error: conflicting declaration of C function ‘void std::__throw_ios_failure(const char*, int)’
  102 |   __throw_ios_failure(const char*, int) __attribute__((__noreturn__,__cold__));
      |   ^~~~~~~~~~~~~~~~~~~
/usr/include/c++/15.1.0/bits/functexcept.h:99:3: note: previous declaration ‘void std::__throw_ios_failure(const char*)’
   99 |   __throw_ios_failure(const char*) __attribute__((__noreturn__,__cold__));
      |   ^~~~~~~~~~~~~~~~~~~
```

`overlandflow_eval_Kin.c` is included inside an `extern "C"` block in `overlandflow_eval_Kin.cpp`. Since `<omp.h>` conditionally includes the C++ header `functexcept.h`, it must be wrapped in `extern "C++"` within the previous `extern "C"` to ensure correct C++ linkage.