### PR TITLE
Compute top and bottom of the domain

### DIFF
--- a/docs/user_manual/keys.rst
+++ b/docs/user_manual/keys.rst
@@ -4571,7 +4571,20 @@ intersect the domain.  The data is written as a ParFlow binary file.
       pfset Solver.PrintTop False                    ## TCL syntax
 
       <runname>.Solver.PrintTop = False              ## Python syntax
-      
+
+*string* **Solver.PrintBottom** False This key is used to turn on printing
+of the bottom of domain data.  'BottomZIndex' is a NX * NY file with the Z
+index of the top of the domain.  A value of -1 indicates an (i,j) column does 
+not intersect the domain.The data is written as a ParFlow binary file.
+
+.. container:: list
+
+   ::
+
+      pfset Solver.PrintBottom False                 ## TCL syntax
+
+      <runname>.Solver.PrintBottom = False           ## Python syntax
+
 *string* **Solver.PrintWells** True This key is used to turn on
 collection and printing of the well data. The data is collected at
 intervals given by values in the timing information section. Printing
@@ -4782,12 +4795,24 @@ Patch index for the top of the domain.  A value of -1 indicates an
 
 .. container:: list
 
-
    ::
 
       pfset Solver.WriteSiloTop True                  ## TCL syntax
 
       <runname>.Solver.WriteSiloTop = True            ## Python syntax
+
+*string* **Solver.WriteSiloBottom** False Key used to control writing of
+one Silo file for the bottom of the domain.  'BottomZIndex' is a NX * NY
+file with the Z index of the bottom of the domain. A value of -1 indicates
+an (i,j) column does not intersect the domain.
+
+.. container:: list
+
+   ::
+
+      pfset Solver.WriteSiloBottom True               ## TCL syntax
+
+      <runname>.Solver.WriteSiloBottom = True         ## Python syntax
 
 *string* **Solver.WritePDISubsurfData** False This key is used to specify exposing of
       the subsurface data, Permeability and Porosity to PDI library. The data is

--- a/pf-keys/definitions/solver.yaml
+++ b/pf-keys/definitions/solver.yaml
@@ -1808,6 +1808,14 @@ Solver:
     domains:
       BoolDomain:
 
+  PrintBottom:
+    help: >
+      [Type: boolean/string] Key used to control writing of one PFB files for the bottom of the domain.  'BottomZIndex' is a NX * NY
+      file with the Z index of the bottom of the domain. A value of -1 indicates an (i,j) column does not intersect the domain.
+    default: False
+    domains:
+      BoolDomain:
+
   # missing from manual
   PrintSlopes:
     help: >
@@ -2448,6 +2456,15 @@ Solver:
       [Type: boolean/string] Key used to control writing of two Silo files for the top of the domain.  'TopZIndex' is a NX * NY
       file with the Z index of the top of the domain. 'TopPatch' is the Patch index for the top of the domain.  A value of -1 indicates an
       (i,j) column does not intersect the domain. format.
+    default: False
+    domains:
+      BoolDomain:
+      RequiresModule: SILO
+  
+    WriteSiloBottom:
+    help: >
+      [Type: boolean/string] Key used to control writing of one Silo file for the bottom of the domain. 'BottomZIndex' is a NX * NY
+      file with the Z index of the bottom of the domain. A value of -1 indicates an (i,j) column does not intersect the domain.
     default: False
     domains:
       BoolDomain:

--- a/pfsimulator/clm/clm.F90
+++ b/pfsimulator/clm/clm.F90
@@ -205,7 +205,6 @@ clm_last_rst,clm_daily_rst,rz_water_stress_typepf, pf_nlevsoi, pf_nlevlak)
   end if ! CLM log
 
      !=== Allocate Memory for Grid Module
-     allocate( counter(nx,ny) )
      allocate (grid(drv%nc,drv%nr),stat=ierr) ; call drv_astp(ierr) 
      do r=1,drv%nr                              ! rows
         do c=1,drv%nc                           ! columns

--- a/pfsimulator/clm/clm.F90
+++ b/pfsimulator/clm/clm.F90
@@ -1,6 +1,6 @@
 !#include <misc.h>
 
-subroutine clm_lsm(pressure,saturation,evap_trans,topo,porosity,pf_dz_mult,istep_pf,dt,time,           &
+subroutine clm_lsm(pressure,saturation,evap_trans,top,bottom,porosity,pf_dz_mult,istep_pf,dt,time,           &
 start_time,pdx,pdy,pdz,ix,iy,nx,ny,nz,nx_f,ny_f,nz_f,nz_rz,ip,npp,npq,npr,gnx,gny,rank,sw_pf,lw_pf,    &
 prcp_pf,tas_pf,u_pf,v_pf,patm_pf,qatm_pf,lai_pf,sai_pf,z0m_pf,displa_pf,                               &
 slope_x_pf,slope_y_pf,                                                                                 &
@@ -55,7 +55,7 @@ clm_last_rst,clm_daily_rst,rz_water_stress_typepf, pf_nlevsoi, pf_nlevlak)
 
   ! basic indices, counters
   integer  :: t                                   ! tile space counter
-  integer  :: l,ll                                   ! layer counter 
+  integer  :: l,ll                                ! layer counter 
   integer  :: r,c                                 ! row,column indices
   integer  :: ierr                                ! error output 
 
@@ -65,7 +65,8 @@ clm_last_rst,clm_daily_rst,rz_water_stress_typepf, pf_nlevsoi, pf_nlevlak)
   real(r8) :: pressure((nx+2)*(ny+2)*(nz+2))     ! pressure head, from parflow on grid w/ ghost nodes for current proc
   real(r8) :: saturation((nx+2)*(ny+2)*(nz+2))   ! saturation from parflow, on grid w/ ghost nodes for current proc
   real(r8) :: evap_trans((nx+2)*(ny+2)*(nz+2))   ! ET flux from CLM to ParFlow on grid w/ ghost nodes for current proc
-  real(r8) :: topo((nx+2)*(ny+2)*(nz+2))         ! mask from ParFlow 0 for inactive, 1 for active, on grid w/ ghost nodes for current proc
+  real(r8) :: top((nx+2)*(ny+2)*(3))             ! top Z index from ParFlow, -1 for inactive, on grid w/ ghost nodes for current proc
+  real(r8) :: bottom((nx+2)*(ny+2)*(3))          ! bottom Z index from ParFlow, -1 for inactive, on grid w/ ghost nodes for current proc
   real(r8) :: porosity((nx+2)*(ny+2)*(nz+2))     ! porosity from ParFlow, on grid w/ ghost nodes for current proc
   real(r8) :: pf_dz_mult((nx+2)*(ny+2)*(nz+2))   ! dz multiplier from ParFlow on PF grid w/ ghost nodes for current proc
   real(r8) :: dt                                 ! parflow dt in parflow time units not CLM time units
@@ -151,7 +152,6 @@ clm_last_rst,clm_daily_rst,rz_water_stress_typepf, pf_nlevsoi, pf_nlevlak)
   integer  :: bj,bl                              ! indices for local looping !BH
 
   integer  :: j_incr,k_incr                      ! increment for j and k to convert 1D vector to 3D i,j,k array
-  integer, allocatable :: counter(:,:) 
   real(r8) :: total
   character*100 :: RI
   real(r8) :: u         ! Tempoary UNDEF Variable
@@ -323,43 +323,34 @@ clm_last_rst,clm_daily_rst,rz_water_stress_typepf, pf_nlevsoi, pf_nlevlak)
         !=== Initialize the CLM topography mask  @RMM  moved up from loop below
         !    This is two components:
         !    1) a x-y mask of 0 o 1 for active inactive and
-     !    2) a z/k mask that takes three values
-     !      (1)= top of LS/PF domain
-     !      (2)= top-nlevsoi and
-     !      (3)= the bottom of the LS/PF domain.
-     if (clm_write_logs==1) write(999,*) "Initialize the CLM topography mask"
+        !    2) a z/k mask that takes three values
+        !      (1)= top of LS/PF domain
+        !      (2)= top-nlevsoi and
+        !      (3)= the bottom of the LS/PF domain.
+        if (clm_write_logs==1 .and. t==1) write(999,*) "Initialize the CLM topography mask"
 
-     i=tile(t)%col
-     j=tile(t)%row
-     counter(i,j) = 0
-     clm(t)%topo_mask(3) = 1
+        i=tile(t)%col
+        j=tile(t)%row
+        clm(t)%topo_mask(3) = 1
 
-     do k = nz, 1, -1 ! PF loop over z
-        l = 1+i + (nx+2)*(j) + (nx+2)*(ny+2)*(k)
-        if (topo(l) > 0) then
-           counter(i,j) = counter(i,j) + 1
-           if (counter(i,j) == 1) then
-              clm(t)%topo_mask(1) = k
-              clm(t)%planar_mask = 1
-           end if
+        l = 1+i + j_incr*(j) + k_incr
+        if (top(l) > 0) then
+           clm(t)%topo_mask(1) = 1+top(l)
+           clm(t)%topo_mask(3) = 1+bottom(l)
+           clm(t)%planar_mask = 1
         endif
+        clm(t)%topo_mask(2) = clm(t)%topo_mask(1)-nlevsoi
 
-        if (topo(l) == 0 .and. topo(l+k_incr) > 0) clm(t)%topo_mask(3) = k+1
+        ! set clm watsat, tksatu from PF porosity
+        do k = 1, nlevsoi ! loop over clm soil layers (1->nlevsoi)
+           ! convert clm space to parflow space, note that PF space has ghost nodes
+           l = 1+i + j_incr*(j) + k_incr*(clm(t)%topo_mask(1)-(k-1))
+           ! put ParFlow porosity in a temp variable passed to clm_ini
+           pf_porosity(k)       = porosity(l)
+           !print*, 'k=',k,'l=',l,'porosity=',porosity(l),'pf_poro=',pf_porosity(k)
 
-     enddo ! k
-
-     clm(t)%topo_mask(2) = clm(t)%topo_mask(1)-nlevsoi
-
-     ! set clm watsat, tksatu from PF porosity
-     do k = 1, nlevsoi ! loop over clm soil layers (1->nlevsoi)
-        ! convert clm space to parflow space, note that PF space has ghost nodes
-        l = 1+i + j_incr*(j) + k_incr*(clm(t)%topo_mask(1)-(k-1))
-        ! put ParFlow porosity in a temp variable passed to clm_ini
-        pf_porosity(k)       = porosity(l)
-        !print*, 'k=',k,'l=',l,'porosity=',porosity(l),'pf_poro=',pf_porosity(k)
-
-        !clm(t)%tksatu(k)       = clm(t)%tkmg(k)*0.57**clm(t)%watsat(k)
-     end do !k
+           !clm(t)%tksatu(k)       = clm(t)%tkmg(k)*0.57**clm(t)%watsat(k)
+        end do !k
 
         call drv_clmini (drv, grid, pf_porosity,tile(t), clm(t), istep_pf) !Initialize CLM Variables
      enddo ! t

--- a/pfsimulator/parflow_lib/CMakeLists.txt
+++ b/pfsimulator/parflow_lib/CMakeLists.txt
@@ -10,7 +10,7 @@ set (SRC_FILES_CONST advect.F
   communication.c
   computation.c
   compute_maximums.c
-  compute_top.c
+  compute_top_and_bottom.c
   compute_patch_top.c
   compute_total_concentration.c
   constantRF.c

--- a/pfsimulator/parflow_lib/compute_top_and_bottom.c
+++ b/pfsimulator/parflow_lib/compute_top_and_bottom.c
@@ -42,12 +42,13 @@
 
 #include "parflow.h"
 
-void ComputeTop(Problem *    problem,      /* General problem information */
-                ProblemData *problem_data  /* Contains geometry information for the problem */
-                )
+void ComputeTopAndBottom(Problem *    problem,      /* General problem information */
+                         ProblemData *problem_data  /* Contains geometry information for the problem */
+                         )
 {
   GrGeomSolid   *gr_solid = ProblemDataGrDomain(problem_data);
   Vector        *top = ProblemDataIndexOfDomainTop(problem_data);
+  Vector        *bottom = ProblemDataIndexOfDomainBottom(problem_data);
   Vector        *perm_x = ProblemDataPermeabilityX(problem_data);
 
   Grid          *grid2d = VectorGrid(top);
@@ -58,7 +59,7 @@ void ComputeTop(Problem *    problem,      /* General problem information */
   SubgridArray  *grid3d_subgrids = GridSubgrids(grid3d);
 
 
-  double *top_data;
+  double *top_data, *bottom_data;
   int index;
 
   VectorUpdateCommHandle   *handle;
@@ -66,7 +67,7 @@ void ComputeTop(Problem *    problem,      /* General problem information */
   (void)problem;
 
   InitVectorAll(top, -1);
-//   PFVConstInit(-1, top);
+  InitVectorAll(bottom, -1);
 
   int is;
   ForSubgridI(is, grid3d_subgrids)
@@ -75,6 +76,7 @@ void ComputeTop(Problem *    problem,      /* General problem information */
     Subgrid       *grid3d_subgrid = SubgridArraySubgrid(grid3d_subgrids, is);
 
     Subvector     *top_subvector = VectorSubvector(top, is);
+    Subvector     *bottom_subvector = VectorSubvector(bottom, is);
 
     int grid3d_ix = SubgridIX(grid3d_subgrid);
     int grid3d_iy = SubgridIY(grid3d_subgrid);
@@ -89,6 +91,7 @@ void ComputeTop(Problem *    problem,      /* General problem information */
     int grid3d_r = SubgridRX(grid3d_subgrid);
 
     top_data = SubvectorData(top_subvector);
+    bottom_data = SubvectorData(bottom_subvector);
 
     int i, j, k;
     GrGeomInLoop(i, j, k,
@@ -102,10 +105,19 @@ void ComputeTop(Problem *    problem,      /* General problem information */
       {
         top_data[index] = k;
       }
+
+      if (bottom_data[index] > k || bottom_data[index] < 0)
+      {
+        bottom_data[index] = k;
+      }
     });
   }      /* End of subgrid loop */
 
   /* Pass top values to neighbors.  */
   handle = InitVectorUpdate(top, VectorUpdateAll);
+  FinalizeVectorUpdate(handle);
+
+  /* Pass bottom values to neighbors.  */
+  handle = InitVectorUpdate(bottom, VectorUpdateAll);
   FinalizeVectorUpdate(handle);
 }

--- a/pfsimulator/parflow_lib/parflow_proto.h
+++ b/pfsimulator/parflow_lib/parflow_proto.h
@@ -1519,8 +1519,8 @@ void cplparflowlclxyedg_(int *   sg,
                          float * localy,
                          int *   ierror);
 
-void ComputeTop(Problem *    problem,
-                ProblemData *problem_data);
+void ComputeTopAndBottom(Problem *    problem,
+                         ProblemData *problem_data);
 
 void ComputePatchTop(Problem *    problem,
                      ProblemData *problem_data);

--- a/pfsimulator/parflow_lib/parflow_proto_f.h
+++ b/pfsimulator/parflow_lib/parflow_proto_f.h
@@ -120,7 +120,7 @@ void SADVECT(double *s, double *sn,
 #define CLM_LSM clm_lsm_
 #endif
 
-#define CALL_CLM_LSM(pressure_data, saturation_data, evap_trans_data, mask, porosity_data,                                                                                                                  \
+#define CALL_CLM_LSM(pressure_data, saturation_data, evap_trans_data, top, bottom, porosity_data,                                                                                                           \
                      dz_mult_data, istep, dt, t, start_time, dx, dy, dz, ix, iy, nx, ny, nz,                                                                                                                \
                      nx_f, ny_f, nz_f, nz_rz, ip, p, q, r, gnx, gny, rank,                                                                                                                                  \
                      sw_data, lw_data, prcp_data, tas_data, u_data, v_data, patm_data, qatm_data,                                                                                                           \
@@ -133,7 +133,7 @@ void SADVECT(double *s, double *sn,
                      clm_beta_function, clm_veg_function, clm_veg_wilting, clm_veg_fieldc, clm_res_sat,                                                                                                     \
                      clm_irr_type, clm_irr_cycle, clm_irr_rate, clm_irr_start, clm_irr_stop,                                                                                                                \
                      clm_irr_threshold, qirr, qirr_inst, iflag, clm_irr_thresholdtype, soi_z, clm_next, clm_write_logs, clm_last_rst, clm_daily_rst, clm_water_stress_type, clm_nlevsoi, clm_nlevlak)       \
-        CLM_LSM(pressure_data, saturation_data, evap_trans_data, mask, porosity_data,                                                                                                                       \
+        CLM_LSM(pressure_data, saturation_data, evap_trans_data, top, bottom, porosity_data,                                                                                                                \
                 dz_mult_data, &istep, &dt, &t, &start_time, &dx, &dy, &dz, &ix, &iy, &nx, &ny, &nz, &nx_f, &ny_f, &nz_f, &nz_rz, &ip, &p, &q, &r, &gnx, &gny, &rank,                                        \
                 sw_data, lw_data, prcp_data, tas_data, u_data, v_data, patm_data, qatm_data,                                                                                                                \
                 lai_data, sai_data, z0m_data, displa_data,                                                                                                                                                  \
@@ -146,7 +146,7 @@ void SADVECT(double *s, double *sn,
                 &clm_res_sat, &clm_irr_type, &clm_irr_cycle, &clm_irr_rate, &clm_irr_start, &clm_irr_stop,                                                                                                  \
                 &clm_irr_threshold, qirr, qirr_inst, iflag, &clm_irr_thresholdtype, &soi_z, &clm_next, &clm_write_logs, &clm_last_rst, &clm_daily_rst, &clm_water_stress_type, &clm_nlevsoi, &clm_nlevlak);
 
-void CLM_LSM(double *pressure_data, double *saturation_data, double *evap_trans_data, double *mask, double *porosity_data,
+void CLM_LSM(double *pressure_data, double *saturation_data, double *evap_trans_data, double *top, double *bottom, double *porosity_data,
              double *dz_mult_data, int *istep, double *dt, double *t, double *start_time,
              double *dx, double *dy, double *dz, int *ix, int *iy, int *nx, int *ny, int *nz,
              int *nx_f, int *ny_f, int *nz_f, int *nz_rz, int *ip, int *p, int *q, int *r, int *gnx, int *gny, int *rank,

--- a/pfsimulator/parflow_lib/problem.c
+++ b/pfsimulator/parflow_lib/problem.c
@@ -453,7 +453,8 @@ ProblemData   *NewProblemData(
 
   ProblemDataIndexOfDomainTop(problem_data) = NewVectorType(grid2d, 1, 1, vector_cell_centered_2D);
   ProblemDataPatchIndexOfDomainTop(problem_data) = NewVectorType(grid2d, 1, 1, vector_cell_centered_2D);
-
+  ProblemDataIndexOfDomainBottom(problem_data) = NewVectorType(grid2d, 1, 1, vector_cell_centered_2D);
+  
   ProblemDataPorosity(problem_data) = NewVectorType(grid, 1, 1, vector_cell_centered);
 
   ProblemDataBCPressureData(problem_data) = NewBCPressureData();
@@ -508,6 +509,7 @@ void          FreeProblemData(
     FreeVector(ProblemDataRealSpaceZ(problem_data));
     FreeVector(ProblemDataIndexOfDomainTop(problem_data));
     FreeVector(ProblemDataPatchIndexOfDomainTop(problem_data));
+    FreeVector(ProblemDataIndexOfDomainBottom(problem_data));
 
     tfree(problem_data);
   }

--- a/pfsimulator/parflow_lib/problem.c
+++ b/pfsimulator/parflow_lib/problem.c
@@ -454,7 +454,7 @@ ProblemData   *NewProblemData(
   ProblemDataIndexOfDomainTop(problem_data) = NewVectorType(grid2d, 1, 1, vector_cell_centered_2D);
   ProblemDataPatchIndexOfDomainTop(problem_data) = NewVectorType(grid2d, 1, 1, vector_cell_centered_2D);
   ProblemDataIndexOfDomainBottom(problem_data) = NewVectorType(grid2d, 1, 1, vector_cell_centered_2D);
-  
+
   ProblemDataPorosity(problem_data) = NewVectorType(grid, 1, 1, vector_cell_centered);
 
   ProblemDataBCPressureData(problem_data) = NewBCPressureData();

--- a/pfsimulator/parflow_lib/problem.h
+++ b/pfsimulator/parflow_lib/problem.h
@@ -141,6 +141,14 @@ typedef struct {
    */
   Vector         *patch_index_of_domain_top;
 
+  /*
+   * This is a NX * NY vector of Z indices to the bottom
+   * of the domain.
+   *
+   * -1 means domain is not present at that i,j index.
+   */
+  Vector         *index_of_domain_bottom;
+
   Vector         *permeability_x;
   Vector         *permeability_y;
   Vector         *permeability_z;
@@ -274,6 +282,7 @@ typedef struct {
 
 #define ProblemDataIndexOfDomainTop(problem_data)  ((problem_data)->index_of_domain_top)
 #define ProblemDataPatchIndexOfDomainTop(problem_data)  ((problem_data)->patch_index_of_domain_top)
+#define ProblemDataIndexOfDomainBottom(problem_data)  ((problem_data)->index_of_domain_bottom)
 
 #define ProblemDataPermeabilityX(problem_data)  ((problem_data)->permeability_x)
 #define ProblemDataPermeabilityY(problem_data)  ((problem_data)->permeability_y)

--- a/pfsimulator/parflow_lib/solver_richards.c
+++ b/pfsimulator/parflow_lib/solver_richards.c
@@ -81,6 +81,7 @@ typedef struct {
   int print_mannings;           /* print mannings? */
   int print_specific_storage;   /* print spec storage? */
   int print_top;                /* print top? */
+  int print_bottom;             /* print bottom? */
   int print_velocities;         /* print velocities? */
   int print_satur;              /* print saturations? */
   int print_mask;               /* print mask? */
@@ -99,6 +100,7 @@ typedef struct {
   int write_pdi_mannings;         /* write mannings via PDI */
   int write_pdi_specific_storage; /* write specific storage via PDI */
   int write_pdi_top;              /* write top via PDI */
+  int write_pdi_bottom;           /* write bottom via PDI */
   int write_pdi_velocities;       /* write velocities via PDI */
   int write_pdi_satur;            /* write saturation via PDI */
   int write_pdi_mask;             /* write mask via PDI */
@@ -122,6 +124,7 @@ typedef struct {
   int write_silo_mannings;      /* write mannings? */
   int write_silo_specific_storage;      /* write specific storage? */
   int write_silo_top;           /* write top? */
+  int write_silo_bottom;           /* write bottom? */
   int write_silo_overland_sum;  /* write sum of overland outflow? */
   int write_silo_overland_bc_flux;      /* write overland outflow boundary condition flux? */
   int write_silo_dzmult;        /* write dz multiplier */
@@ -837,9 +840,20 @@ SetupRichards(PFModule * this_module)
     WritePFBinary(file_prefix, file_postfix, ProblemDataPatchIndexOfDomainTop(problem_data));
   }
 
+  if (public_xtra->print_bottom)
+  {
+    strcpy(file_postfix, "bottom_zindex");
+    WritePFBinary(file_prefix, file_postfix, ProblemDataIndexOfDomainBottom(problem_data));
+  }
+
   if (public_xtra->write_pdi_top)
   {
     printf("WritePDITop -- not yet implemented\n");
+  }
+
+  if (public_xtra->write_pdi_bottom)
+  {
+    printf("WritePDIBottom -- not yet implemented\n");
   }
 
   if (public_xtra->write_silo_top)
@@ -851,6 +865,14 @@ SetupRichards(PFModule * this_module)
     strcpy(file_type, "top_patch");
     WriteSilo(file_prefix, file_type, file_postfix, ProblemDataPatchIndexOfDomainTop(problem_data),
               t, 0, "TopPatch");
+  }
+
+  if (public_xtra->write_silo_bottom)
+  {
+    strcpy(file_postfix, "");
+    strcpy(file_type, "bottom_zindex");
+    WriteSilo(file_prefix, file_type, file_postfix, ProblemDataIndexOfDomainBottom(problem_data),
+              t, 0, "BottomZIndex");
   }
 
   if (!amps_Rank(amps_CommWorld))
@@ -5757,6 +5779,11 @@ SolverRichardsNewPublicXtra(char *name)
   switch_value = NA_NameToIndexExitOnError(switch_na, switch_name, key);
   public_xtra->print_top = switch_value;
 
+  sprintf(key, "%s.PrintBottom", name);
+  switch_name = GetStringDefault(key, "False");
+  switch_value = NA_NameToIndexExitOnError(switch_na, switch_name, key);
+  public_xtra->print_bottom = switch_value;
+
   sprintf(key, "%s.PrintPressure", name);
   switch_name = GetStringDefault(key, "True");
   switch_value = NA_NameToIndexExitOnError(switch_na, switch_name, key);
@@ -6223,6 +6250,10 @@ SolverRichardsNewPublicXtra(char *name)
   switch_value = NA_NameToIndexExitOnError(switch_na, switch_name, key);
   public_xtra->write_silo_top = switch_value;
 
+  sprintf(key, "%s.WriteSiloBottom", name);
+  switch_name = GetStringDefault(key, "False");
+  switch_value = NA_NameToIndexExitOnError(switch_na, switch_name, key);
+  public_xtra->write_silo_bottom = switch_value;
 
   /* Initialize silo if necessary */
   if (public_xtra->write_silo_subsurf_data ||
@@ -6237,6 +6268,7 @@ SolverRichardsNewPublicXtra(char *name)
       public_xtra->write_silo_mannings ||
       public_xtra->write_silo_mask ||
       public_xtra->write_silo_top ||
+      public_xtra->write_silo_bottom ||
       public_xtra->write_silo_overland_sum ||
       public_xtra->write_silo_overland_bc_flux ||
       public_xtra->write_silo_dzmult || public_xtra->write_silo_CLM)

--- a/pfsimulator/parflow_lib/solver_richards.c
+++ b/pfsimulator/parflow_lib/solver_richards.c
@@ -2558,8 +2558,8 @@ AdvanceRichards(PFModule * this_module, double start_time,      /* Starting time
         sp = SubvectorData(s_sub);
         pp = SubvectorData(p_sub);
         et = SubvectorData(et_sub);
-        top = SubvectorData(top_sub);
-        bot = SubvectorData(bot_sub);
+        top_dat = SubvectorData(top_sub);
+        bot_dat = SubvectorData(bot_sub);
         po_dat = SubvectorData(po_sub);
         dz_dat = SubvectorData(dz_sub);
 
@@ -2689,8 +2689,8 @@ AdvanceRichards(PFModule * this_module, double start_time,      /* Starting time
           {
             /*BH: added vegetation forcings and associated option (clm_forc_veg) */
             clm_file_dir_length = strlen(public_xtra->clm_file_dir);
-            CALL_CLM_LSM(pp, sp, et, top, bot, po_dat, dz_dat, istep, cdt, t,
-                         start_time, dx, dy, dz, ix, iy, nx, ny, nz,
+            CALL_CLM_LSM(pp, sp, et, top_dat, bot_dat, po_dat, dz_dat, istep,
+                         cdt, t, start_time, dx, dy, dz, ix, iy, nx, ny, nz,
                          nx_f, ny_f, nz_f, nz_rz, ip, p, q, r, gnx,
                          gny, rank, sw_data, lw_data, prcp_data,
                          tas_data, u_data, v_data, patm_data,

--- a/pfsimulator/parflow_lib/solver_richards.c
+++ b/pfsimulator/parflow_lib/solver_richards.c
@@ -479,7 +479,7 @@ SetupRichards(PFModule * this_module)
 
   /* Do turning bands (and other stuff maybe) */
   PFModuleInvokeType(SetProblemDataInvoke, set_problem_data, (problem_data));
-  ComputeTop(problem, problem_data);
+  ComputeTopAndBottom(problem, problem_data);
 
   if (public_xtra->print_top || public_xtra->write_silo_top)
   {

--- a/pfsimulator/parflow_lib/solver_richards.c
+++ b/pfsimulator/parflow_lib/solver_richards.c
@@ -1828,8 +1828,8 @@ AdvanceRichards(PFModule * this_module, double start_time,      /* Starting time
 #ifdef HAVE_CLM
   Grid *grid = (instance_xtra->grid);
   Subgrid *subgrid;
-  Subvector *p_sub, *s_sub, *et_sub, *m_sub, *po_sub, *dz_sub;
-  double *pp, *sp, *et, *ms, *po_dat, *dz_dat;
+  Subvector *p_sub, *s_sub, *et_sub, *po_sub, *dz_sub;
+  double *pp, *sp, *et, *po_dat, *dz_dat;
 
   /* IMF: For CLM met forcing (local to AdvanceRichards) */
   int istep;                    // IMF: counter for clm output times
@@ -2447,11 +2447,19 @@ AdvanceRichards(PFModule * this_module, double start_time,      /* Starting time
         int soi_z;
         int x, y, z;
 
+        Vector *top = ProblemDataIndexOfDomainTop(problem_data);
+        Vector *bot = ProblemDataIndexOfDomainBottom(problem_data);
+        Subvector *top_sub;
+        Subvector *bot_sub;
+        double *top_dat;
+        double *bot_dat;
+
         subgrid = GridSubgrid(grid, is);
         p_sub = VectorSubvector(instance_xtra->pressure, is);
         s_sub = VectorSubvector(instance_xtra->saturation, is);
         et_sub = VectorSubvector(evap_trans, is);
-        m_sub = VectorSubvector(instance_xtra->mask, is);
+        top_sub = VectorSubvector(top, is);
+        bot_sub = VectorSubvector(bot, is);
         po_sub = VectorSubvector(porosity, is);
         dz_sub = VectorSubvector(instance_xtra->dz_mult, is);
 
@@ -2528,7 +2536,8 @@ AdvanceRichards(PFModule * this_module, double start_time,      /* Starting time
         sp = SubvectorData(s_sub);
         pp = SubvectorData(p_sub);
         et = SubvectorData(et_sub);
-        ms = SubvectorData(m_sub);
+        top = SubvectorData(top_sub);
+        bot = SubvectorData(bot_sub);
         po_dat = SubvectorData(po_sub);
         dz_dat = SubvectorData(dz_sub);
 
@@ -2658,7 +2667,7 @@ AdvanceRichards(PFModule * this_module, double start_time,      /* Starting time
           {
             /*BH: added vegetation forcings and associated option (clm_forc_veg) */
             clm_file_dir_length = strlen(public_xtra->clm_file_dir);
-            CALL_CLM_LSM(pp, sp, et, ms, po_dat, dz_dat, istep, cdt, t,
+            CALL_CLM_LSM(pp, sp, et, top, bot, po_dat, dz_dat, istep, cdt, t,
                          start_time, dx, dy, dz, ix, iy, nx, ny, nz,
                          nx_f, ny_f, nz_f, nz_rz, ip, p, q, r, gnx,
                          gny, rank, sw_data, lw_data, prcp_data,


### PR DESCRIPTION
In this Pull Request is implemented the computation of a vector storing the index values for the bottom of the domain.
- This PR is meant to pave the road for an upcoming bottom BC feature.
- In addition, this PR addresses Issue #588, where the indices for the top and bottom of the domain are passed onto CLM, instead of having CLM compute it again.