### PR TITLE
Fix process topology of python tests

### DIFF
--- a/test/python/CMakeLists.txt
+++ b/test/python/CMakeLists.txt
@@ -95,7 +95,7 @@ if ( ${PARFLOW_AMPS_LAYER} IN_LIST PARFLOW_AMPS_LAYER_REQUIRE_MPI )
   list(APPEND PARALLEL_3DTOPO_TESTS
     default_single
     default_single_read_porosity
-    )
+  )
 
   if(${PARFLOW_HAVE_HYPRE})
     list(APPEND PARALLEL_3DTOPO_TESTS
@@ -104,7 +104,7 @@ if ( ${PARFLOW_AMPS_LAYER} IN_LIST PARFLOW_AMPS_LAYER_REQUIRE_MPI )
 
     if(${PARFLOW_HAVE_NETCDF})
       list(APPEND PARALLEL_3DTOPO_TESTS
-	default_richards_restart_netcdf)
+	      default_richards_restart_netcdf)
     endif()
 
     list(APPEND PARALLEL_2DTOPO_TESTS
@@ -115,12 +115,12 @@ if ( ${PARFLOW_AMPS_LAYER} IN_LIST PARFLOW_AMPS_LAYER_REQUIRE_MPI )
       LW_var_dz_spinup
       overland_slopingslab_KWE
       richards_box_proctest_vardz
-            reservoir_mpi_test
+      reservoir_mpi_test
     )
 
     if(${PARFLOW_HAVE_SILO})
       list(APPEND PARALLEL_2DTOPO_TESTS
-	default_overland.pfmg_octree.jac)
+	      default_overland.pfmg_octree.jac)
     endif()
   endif()
 

--- a/test/python/default_overland.pfmg_octree.jac.py
+++ b/test/python/default_overland.pfmg_octree.jac.py
@@ -5,6 +5,7 @@
 
 from parflow import Run
 from parflow.tools.fs import mkdir, get_absolute_path
+import argparse
 
 dover = Run("default_overland_pfmg_octree_jac", __file__)
 
@@ -12,9 +13,15 @@ dover = Run("default_overland_pfmg_octree_jac", __file__)
 
 dover.FileVersion = 4
 
-dover.Process.Topology.P = 1
-dover.Process.Topology.Q = 1
-dover.Process.Topology.R = 1
+parser = argparse.ArgumentParser()
+parser.add_argument("-p", "--p", default=1)
+parser.add_argument("-q", "--q", default=1)
+parser.add_argument("-r", "--r", default=1)
+args = parser.parse_args()
+
+dover.Process.Topology.P = args.p
+dover.Process.Topology.Q = args.q
+dover.Process.Topology.R = args.r
 
 # ---------------------------------------------------------
 # Computational Grid

--- a/test/python/default_single.py
+++ b/test/python/default_single.py
@@ -5,7 +5,7 @@
 from parflow import Run
 from parflow.tools.fs import mkdir, get_absolute_path
 from parflow.tools.compare import pf_test_file, pf_test_file_with_abs
-import sys
+import sys, argparse
 
 run_name = "default_single"
 default_single = Run(run_name, __file__)
@@ -16,13 +16,19 @@ correct_output_dir_name = get_absolute_path("../correct_output")
 
 default_single.FileVersion = 4
 
+parser = argparse.ArgumentParser()
+parser.add_argument("-p", "--p", default=1)
+parser.add_argument("-q", "--q", default=1)
+parser.add_argument("-r", "--r", default=1)
+args = parser.parse_args()
+
 # -----------------------------------------------------------------------------
 # Process Topology
 # -----------------------------------------------------------------------------
 
-default_single.Process.Topology.P = 1
-default_single.Process.Topology.Q = 1
-default_single.Process.Topology.R = 1
+default_single.Process.Topology.P = args.p
+default_single.Process.Topology.Q = args.q
+default_single.Process.Topology.R = args.r
 
 # -----------------------------------------------------------------------------
 # Computational Grid

--- a/test/python/default_single_read_porosity.py
+++ b/test/python/default_single_read_porosity.py
@@ -5,7 +5,7 @@
 from parflow import Run
 from parflow.tools.fs import cp, mkdir, get_absolute_path
 from parflow.tools.compare import pf_test_file, pf_test_file_with_abs
-import sys
+import sys, argparse
 
 run_name = "default_single"
 default_single = Run(run_name, __file__)
@@ -16,13 +16,19 @@ correct_output_dir_name = get_absolute_path("../correct_output")
 
 default_single.FileVersion = 4
 
+parser = argparse.ArgumentParser()
+parser.add_argument("-p", "--p", default=1)
+parser.add_argument("-q", "--q", default=1)
+parser.add_argument("-r", "--r", default=1)
+args = parser.parse_args()
+
 # -----------------------------------------------------------------------------
 # Process Topology
 # -----------------------------------------------------------------------------
 
-default_single.Process.Topology.P = 1
-default_single.Process.Topology.Q = 1
-default_single.Process.Topology.R = 1
+default_single.Process.Topology.P = args.p
+default_single.Process.Topology.Q = args.q
+default_single.Process.Topology.R = args.r
 
 # -----------------------------------------------------------------------------
 # Computational Grid

--- a/test/python/reservoir_mpi_test.py
+++ b/test/python/reservoir_mpi_test.py
@@ -10,7 +10,7 @@ import pandas as pd
 import parflow as pf
 from parflow.tools.compare import pf_test_file_with_abs
 import numpy as np
-import sys
+import sys, argparse
 
 run_name = "reservoir_mpi_test"
 sloping_slab = Run(run_name, __file__)
@@ -19,9 +19,15 @@ sloping_slab = Run(run_name, __file__)
 
 sloping_slab.FileVersion = 4
 
-sloping_slab.Process.Topology.P = 1
-sloping_slab.Process.Topology.Q = 1
-sloping_slab.Process.Topology.R = 1
+parser = argparse.ArgumentParser()
+parser.add_argument("-p", "--p", default=1)
+parser.add_argument("-q", "--q", default=1)
+parser.add_argument("-r", "--r", default=1)
+args = parser.parse_args()
+
+sloping_slab.Process.Topology.P = args.p
+sloping_slab.Process.Topology.Q = args.q
+sloping_slab.Process.Topology.R = args.r
 
 # ---------------------------------------------------------
 # Computational Grid


### PR DESCRIPTION
This PR addresses Issue #643:
- Some python tests were running with 2D or 3D topologies while setting (P, Q, R) = (1, 1, 1) in the input script;
- The python tests where this happened (including `default_single.py`) were identified;
- This PR fixes the test scripts and ensures they are running the correct topologies.