### PR TITLE
Cleanup Fortran checks in CMAKE

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -438,15 +438,13 @@ CHECK_Fortran_SOURCE_COMPILES("      program main
       end" FORTRAN_77_WORKS)
 
 # Check if Fortran 90 compile works with free format
-set(SAVE_CMAKE_REQUIRED_FLAGS ${CMAKE_REQUIRED_FLAGS})
-set(CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS} ${CMAKE_Fortran_FORMAT_FREE_FLAG}")
 CHECK_Fortran_SOURCE_COMPILES("program main
   implicit none
 
   write ( *, '(a)' ) '  Hello, world!'
 
   stop
-end" FORTRAN_F90_WORKS)
+end" FORTRAN_F90_WORKS SRC_EXT .F90)
 
 #
 # Determine syntax for writing binary file under Fortran
@@ -458,7 +456,7 @@ CHECK_Fortran_SOURCE_COMPILES("program freeform
    write(10) \"first\"
    write(10) \"second\"
    close(UNIT=10)
- end program freeform" HAVE_FC_ACCESS_STREAM)
+ end program freeform" HAVE_FC_ACCESS_STREAM SRC_EXT .F90)
 
 # Check whether the Fortran compiler supports the access="sequential" open syntax
 CHECK_Fortran_SOURCE_COMPILES("program freeform
@@ -466,12 +464,14 @@ CHECK_Fortran_SOURCE_COMPILES("program freeform
   write(10) \"first\"
   write(10) \"second\"
   close(UNIT=10)
-end program freeform" HAVE_FC_ACCESS_SEQUENTIAL)
+end program freeform" HAVE_FC_ACCESS_SEQUENTIAL SRC_EXT .F90)
 
 #
 # Set implicit none flag on Fortran compiles
 #
 include(CheckFortranCompilerFlag)
+
+set(SAVE_CMAKE_REQUIRED_FLAGS ${CMAKE_REQUIRED_FLAGS})
 
 set(none_test 0)
 foreach(flag "-implicitnone" "-fimplicit-none" "-u" "-Wimplicit none")
@@ -513,6 +513,7 @@ endif (${HAVE_FC_ACCESS_STREAM})
 include (TestBigEndian)
 include(CheckSymbolExists)
 include(CheckIncludeFiles)
+include(CheckFunctionExists)
 
 test_big_endian(PARFLOW_HAVE_BIG_ENDIAN)
 set(CASC_HAVE_BIGENDIAN ${PARFLOW_HAVE_BIG_ENDIAN})
@@ -531,6 +532,34 @@ endif ( ${PARFLOW_HAVE_MALLOC_H} )
 # Check for mallinfo
 check_symbol_exists(mallinfo2 malloc.h PARFLOW_HAVE_MALLINFO2)
 check_symbol_exists(mallinfo malloc.h PARFLOW_HAVE_MALLINFO)
+
+# Check if libm is required
+
+# Check if acos is available without additional libraries
+check_function_exists(acos HAVE_ACOS)
+
+if(NOT HAVE_ACOS)
+  # Save the current required libraries
+  set(CMAKE_REQUIRED_LIBRARIES_SAVE ${CMAKE_REQUIRED_LIBRARIES})
+  
+  # Try with libm
+  set(CMAKE_REQUIRED_LIBRARIES m)
+  check_function_exists(acos HAVE_ACOS_WITH_LIBM)
+  
+  # Restore the original required libraries
+  set(CMAKE_REQUIRED_LIBRARIES ${CMAKE_REQUIRED_LIBRARIES_SAVE})
+  
+  if(HAVE_ACOS_WITH_LIBM)
+    set(MATH_LIBRARY m)
+    message(STATUS "Linking with libm math library")
+  else()
+    message(FATAL_ERROR "acos function not found")
+  endif()
+endif()
+
+#-----------------------------------------------------------------------------
+# Check compiling with CLM / ECLM
+#-----------------------------------------------------------------------------
 
 option(PARFLOW_HAVE_CLM "Compile with CLM" "OFF")
 
@@ -557,6 +586,7 @@ if ( ${PARFLOW_HAVE_ECLM} )
     set (HAVE_ECLM ${PARFLOW_HAVE_ECLM})
   endif (HAVE_OAS3)
 endif ( ${PARFLOW_HAVE_ECLM} )
+
 #
 # Parflow specific configuration options
 #

--- a/bin/valgrind.sup
+++ b/bin/valgrind.sup
@@ -438,6 +438,43 @@
    fun:amps_SFBCast
 }
 
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:calloc
+   obj:/usr/lib64/libibverbs.so.1.14.48.0
+   fun:nl_recvmsgs_report
+   fun:nl_recvmsgs
+   obj:/usr/lib64/libibverbs.so.1.14.48.0
+   obj:/usr/lib64/libibverbs.so.1.14.48.0
+   obj:/usr/lib64/libibverbs.so.1.14.48.0
+   fun:ibv_get_device_list
+   obj:*
+   obj:*
+   obj:*
+   fun:rdma_cm_get_hca_type
+}
+
+
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:calloc
+   obj:/usr/lib64/libmlx4.so.1.0.48.0
+   obj:/usr/lib64/libibverbs.so.1.14.48.0
+   obj:/usr/lib64/libibverbs.so.1.14.48.0
+   obj:/usr/lib64/libibverbs.so.1.14.48.0
+   fun:ibv_get_device_list
+   obj:*
+   obj:*
+   obj:*
+   fun:rdma_cm_get_hca_type
+   fun:MPIDI_CH3_Init
+   fun:MPID_Init
+}
+
 ###############################################################
 #
 # Intel F90

--- a/pfsimulator/parflow_exe/CMakeLists.txt
+++ b/pfsimulator/parflow_exe/CMakeLists.txt
@@ -72,6 +72,11 @@ if (${PARFLOW_HAVE_SLURM})
   target_link_libraries (parflow ${SLURM_LIBRARIES})
 endif (${PARFLOW_HAVE_SLURM})
 
+# Link the math library if needed
+if(PARFLOW_MATH_LIBRARY)
+    target_link_libraries(parflow ${MATH_LIBRARY})
+endif()
+
 if( ${PARFLOW_ENABLE_PROFILING} )
   set_target_properties(parflow PROPERTIES LINK_FLAGS ${PARFLOW_PROFILE_OPTS})
 endif( ${PARFLOW_ENABLE_PROFILING} )


### PR DESCRIPTION
The CMAKE checking was not fully using latest features in CMAKE macros for checking Fortran.   Updated and cleaned up CMAKE support.
Added missing math library support when compiling with LLVM/Clang C/C++ and GCC Fortran.