### PR TITLE
Fix data_size of Vector calculation

### DIFF
--- a/pfsimulator/parflow_lib/vector.c
+++ b/pfsimulator/parflow_lib/vector.c
@@ -272,12 +272,12 @@ static Vector  *NewTempVector(
 
     n = SubvectorNX(new_sub) * SubvectorNY(new_sub) * SubvectorNZ(new_sub);
 
-    data_size = n;
+    data_size += n;
 
     VectorSubvector(new_vector, i) = new_sub;
   }
 
-  (new_vector->data_size) = data_size;    /* data_size is size of data including ghost points */
+  SizeOfVector(new_vector) = data_size;    /* data_size is size of data including ghost points */
 
   VectorGrid(new_vector) = grid;  /* Grid that this vector is on */
 


### PR DESCRIPTION
The `data_size` parameter for the `Vector` structure is calculated in the following lines:

https://github.com/parflow/parflow/blob/c6442a42c59e37e63ec61f82d8192c41ff48e401/pfsimulator/parflow_lib/vector.c#L273-L275

If there are more than one `Subvector` structures in the `Vector`, then the `data_size` is equal to the `data_size` of the last `Subvector` and not the total `data_size` amongst `Subvector` structures.
In the current state of the code, each process is being assigned a single Subgrid, which is why this bug has gone undetected.

This PR fixes this bug.