### PR TITLE
Update model equation for hydraulic conductivity

### DIFF
--- a/docs/user_manual/models.rst
+++ b/docs/user_manual/models.rst
@@ -90,8 +90,12 @@ fluxes). The hydraulic conductivity can be written as,
    :label: hydcond
 
    \begin{aligned}
-   K(p) =  \frac{{\bar k}k_r(p)}{\mu}
+   K(p) =  \frac{{\bar k} k_r(p) \rho g}{\mu},
    \end{aligned}
+
+where :math:`\bar k` is the intrinsic permeability tensor, :math:`k_r(p)` is 
+the relative permeability, :math:`\rho` is the density, :math:`g` is the 
+gravitational acceleration, and :math:`\mu` is the viscosity.
 
 Boundary conditions can be stated as,
 

--- a/docs/user_manual/models.rst
+++ b/docs/user_manual/models.rst
@@ -93,8 +93,8 @@ fluxes). The hydraulic conductivity can be written as,
    K(p) =  \frac{{\bar k} k_r(p) \rho g}{\mu},
    \end{aligned}
 
-where :math:`\bar k` is the intrinsic permeability tensor, :math:`k_r(p)` is 
-the relative permeability, :math:`\rho` is the density, :math:`g` is the 
+where :math:`\bar k` is the intrinsic permeability tensor, :math:`k_r(p)` is
+the relative permeability, :math:`\rho` is the density, :math:`g` is the
 gravitational acceleration, and :math:`\mu` is the viscosity.
 
 Boundary conditions can be stated as,


### PR DESCRIPTION
Added density and gravitational equation. Without those, the units don't match up. K(p) should be in in LT^-1.
Since  \bar k is in L^2, k_r is in [-], and \mu is in ML^-1T^-1, we would currently be at M^-1LT, which is why we need g in LT^-2 and \rho in ML^-3. Also, see equation (1) here: 
Blake, G.R. et al. (2008). Permeability. In: Chesworth, W. (eds) Encyclopedia of Soil Science. Encyclopedia of Earth Sciences Series. Springer, Dordrecht. https://doi.org/10.1007/978-1-4020-3995-9_425